### PR TITLE
Fixed docker build cannot create regular file '/app/etc/'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,12 +30,12 @@ FROM base as app
 LABEL description="EVEmu Server"
 # copy our utils to this image
 COPY --from=app-build /src/utils/ /src/utils
+# copy our compiled code to this image
+COPY --from=app-build /app/ /app
 # install the configuration files
 RUN cp /src/utils/config/log.ini /app/etc/; cp /src/utils/config/eve-server.xml /app/etc/
 # add in the files to load the database
 ADD /sql/ /src/sql
-# copy our compiled code to this image
-COPY --from=app-build /app/ /app
 
 RUN cd /src/sql && ./get_evedbtool.sh
 


### PR DESCRIPTION
docker build err message
```
[root@VM_0_14_centos evemu_Crucible]# docker-compose -p evemu up --build -d

...
...
...

Step 17/24 : COPY --from=app-build /src/utils/ /src/utils
 ---> 7e6b92091285
Step 18/24 : RUN cp /src/utils/config/log.ini /app/etc/; cp /src/utils/config/eve-server.xml /app/etc/
 ---> Running in 70d6375ef396
cp: cannot create regular file '/app/etc/': No such file or directory
cp: cannot create regular file '/app/etc/': No such file or directory
The command '/bin/sh -c cp /src/utils/config/log.ini /app/etc/; cp /src/utils/config/eve-server.xml /app/etc/' returned a non-zero code: 1
ERROR: Service 'server' failed to build
```
