### PR TITLE
Fix for broken `.giveallskills` command

### DIFF
--- a/src/eve-server/admin/GMCommands.cpp
+++ b/src/eve-server/admin/GMCommands.cpp
@@ -597,7 +597,7 @@ PyResult Command_giveallskills(Client* who, CommandDB* db, PyServiceMgr* service
         for (; cur != skillList.end(); ++cur) {
             skillID = *cur;
             if (character->HasSkillTrainedToLevel(skillID, level)) {
-                return PyStatic.NewNone();
+                continue;
             } else if (character->HasSkill(skillID)) {
                 skill = character->GetSkill(skillID);
                 //oldLevel = skill->GetAttribute(AttrSkillLevel).get_uint32();


### PR DESCRIPTION
This bug prevents the command to successfully provide the target with all the skills in the game having level 5 each if there's any skill already learnt to 5 (an easy way to achieve this is to use `Give skills` UI for something like a T2 ship and/or T2 weapon).