### PR TITLE
Reimplemented GMCommands::giveallskills()

### DIFF
--- a/src/eve-server/admin/CommandDB.h
+++ b/src/eve-server/admin/CommandDB.h
@@ -31,15 +31,21 @@ class CommandDB
 : public ServiceDB
 {
  public:
+    typedef std::pair<uint32, int32> skillStateDescriptor;
+    typedef std::vector<skillStateDescriptor> charSkillStates;
+
     bool ItemSearch(const char *query, std::map<uint32, std::string> &into);
     bool ItemSearch(uint32 typeID, uint32 &actualTypeID, std::string &actualTypeName,
                     uint32 &actualGroupID, uint32 &actualCategoryID, double &actualRadius);
     int GetAttributeID(const char *attributeName);
     int GetAccountID(std::string name);
     bool FullSkillList(std::vector<uint32> &skillList);
+    static bool NotFullyLearnedSkillList(charSkillStates &skillList, uint32 charID);
     uint32_t GetStation(const char *name);
     uint32_t GetSolarSystem(const char *name);
 
+private:
+    static void PushNonPublishedSkills(std::vector<uint32> &skillList);
 };
 
 


### PR DESCRIPTION
As stated in https://github.com/EvEmu-Project/evemu_Crucible/pull/130 previous implementation was slow and led to grinding.

I've reimplemented it with a smart SQL that only returns those skills that need to me injected and/or upped to level 5.

The query rendered is like:
```MySQL
WITH skillids AS (
    SELECT typeID
    FROM `invTypes`
    WHERE (
            (`groupID` IN (SELECT groupID FROM invGroups WHERE categoryID = % u))
            AND (published = 1))
       OR typeID IN (3755, 3758, 9955, 10264, 11075, 11078, 19430, 28604)  -- this clause is rendered if `unpubSkills` is not empty
)

SELECT si.typeID   AS typeID,
       e.itemID    AS itemID,
       ea.valueInt AS valueInt
FROM skillids si
         LEFT OUTER JOIN entity e ON e.locationID = % u AND e.typeID = si.typeID
         LEFT OUTER JOIN entity_attributes ea ON e.itemID = ea.itemID AND ea.attributeID = % u
WHERE (ea.valueInt < 5 OR ea.valueInt IS NULL)
```