### PR TITLE
Added the ability to use External Databases

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,11 @@ services:
     links:
       - "db"
     environment:
+      - MARIADB_HOST=db
+      - MARIADB_USER=evemu
+      - MARIADB_PASSWORD=evemu
+      - MARIADB_DATABASE=evemu
+      - MARIADB_PORT=3306
       - SEED_MARKET=FALSE # Set to TRUE to seed the market when the server starts for the first time
       - SEED_SATURATION=80 # Set saturation level of seed
       - SEED_REGIONS=Derelik,The Citadel,The Forge # Define regions to be seeded

--- a/utils/config/eve-server.xml
+++ b/utils/config/eve-server.xml
@@ -257,11 +257,11 @@ boolean can use either 0/1 OR true/false.
     </threads>
 
     <database>
-        <host>db</host><!--  must be 'localhost' for socket connection -->
-        <username>evemu</username>
-        <password>evemu</password>
-        <db>evemu</db>
-        <port>3306</port><!-- 3306 default -->
+        <host>database_host</host><!--  must be 'localhost' for socket connection -->
+        <username>database_username</username>
+        <password>database_password</password>
+        <db>database_name</db>
+        <port>database_port</port><!-- 3306 default -->
         <ssl>false</ssl><!-- bool   enable ssl for db connection (NOTE: NOT coded. DO NOT USE) -not needed when using socket under linux-->
         <compress>false</compress><!-- bool   compressed protocol for client server communication - not sure if needed. -->
         <useSocket>false</useSocket><!-- bool  use socket connection instead of port (MUST be local)  (SIGPIPE hits on debug code) -->

--- a/utils/container-scripts/db_init.sh
+++ b/utils/container-scripts/db_init.sh
@@ -32,7 +32,7 @@ sed -i "s/database_username/$MARIADB_USER/" /src/utils/config/eve-server.xml
 sed -i "s/database_password/$MARIADB_PASSWORD/" /src/utils/config/eve-server.xml
 sed -i "s/database_name/$MARIADB_DATABASE/" /src/utils/config/eve-server.xml
 sed -i "s/database_port/$MARIADB_PORT/" /src/utils/config/eve-server.xml
-cp /src/utils/config/eve-server.xml /app/etc/eve-server.xml
+
 
 # Write evedb.yaml based upon above variables
 cd /src/sql

--- a/utils/container-scripts/db_init.sh
+++ b/utils/container-scripts/db_init.sh
@@ -29,7 +29,7 @@ waitContainer evemu_db
 cd /src/sql
 cat >/src/sql/evedb.yaml <<EOF
 base-dir: /src/sql/base
-db-database: MARIADB_DATABASE
+db-database: $MARIADB_DATABASE
 db-host: $MARIADB_HOST
 db-pass: $MARIADB_PASSWORD
 db-port: 3306

--- a/utils/container-scripts/db_init.sh
+++ b/utils/container-scripts/db_init.sh
@@ -7,6 +7,7 @@ MARIADB_HOST="${MARIADB_HOST:-db}"
 MARIADB_DATABASE="${MARIADB_DATABASE:-evemu}"
 MARIADB_PASSWORD="${MARIADB_PASSWORD:-evemu}"
 MARIADB_USER="${MARIADB_USER:-evemu}"
+MARIADB_PORT="${MARIADB_PORT:-3306}"
 
 
 # Get script path:
@@ -25,6 +26,13 @@ function waitContainer {
 echo "Waiting for DB to start..."
 waitContainer evemu_db
 
+#Write the eve-server.xml variables
+sed 's/database_host/$MARIADB_HOST/' /src/utils/config/eve-server.xml
+sed 's/database_username/$MARIADB_USER/' /src/utils/config/eve-server.xml
+sed 's/database_password/$MARIADB_PASSWORD/' /src/utils/config/eve-server.xml
+sed 's/database_name/$MARIADB_DATABASE/' /src/utils/config/eve-server.xml
+sed 's/database_port/$MARIADB_PORT/' /src/utils/config/eve-server.xml
+
 # Write evedb.yaml based upon above variables
 cd /src/sql
 cat >/src/sql/evedb.yaml <<EOF
@@ -32,7 +40,7 @@ base-dir: /src/sql/base
 db-database: $MARIADB_DATABASE
 db-host: $MARIADB_HOST
 db-pass: $MARIADB_PASSWORD
-db-port: 3306
+db-port: $MARIADB_PORT
 db-user: $MARIADB_USER
 log-level: Info
 migrations-dir: /src/sql/migrations

--- a/utils/container-scripts/db_init.sh
+++ b/utils/container-scripts/db_init.sh
@@ -7,7 +7,7 @@ MARIADB_HOST="${MARIADB_HOST:-db}"
 MARIADB_DATABASE="${MARIADB_DATABASE:-evemu}"
 MARIADB_PASSWORD="${MARIADB_PASSWORD:-evemu}"
 MARIADB_USER="${MARIADB_USER:-evemu}"
-MARIADB_PORT="${MARIADB_PORT:-'3306'}"
+MARIADB_PORT="${MARIADB_PORT:-3306}"
 
 
 # Get script path:
@@ -32,6 +32,7 @@ sed -i "s/database_username/$MARIADB_USER/" /src/utils/config/eve-server.xml
 sed -i "s/database_password/$MARIADB_PASSWORD/" /src/utils/config/eve-server.xml
 sed -i "s/database_name/$MARIADB_DATABASE/" /src/utils/config/eve-server.xml
 sed -i "s/database_port/$MARIADB_PORT/" /src/utils/config/eve-server.xml
+cp /src/utils/config/eve-server.xml /app/etc/eve-server.xml
 
 # Write evedb.yaml based upon above variables
 cd /src/sql

--- a/utils/container-scripts/db_init.sh
+++ b/utils/container-scripts/db_init.sh
@@ -29,11 +29,11 @@ waitContainer evemu_db
 cd /src/sql
 cat >/src/sql/evedb.yaml <<EOF
 base-dir: /src/sql/base
-db-database: evemu
-db-host: db
-db-pass: evemu
+db-database: MARIADB_DATABASE
+db-host: $MARIADB_HOST
+db-pass: $MARIADB_PASSWORD
 db-port: 3306
-db-user: evemu
+db-user: $MARIADB_USER
 log-level: Info
 migrations-dir: /src/sql/migrations
 EOF

--- a/utils/container-scripts/db_init.sh
+++ b/utils/container-scripts/db_init.sh
@@ -27,11 +27,11 @@ echo "Waiting for DB to start..."
 waitContainer evemu_db
 
 #Write the eve-server.xml variables
-sed -i 's/database_host/$MARIADB_HOST/' /src/utils/config/eve-server.xml
-sed -i 's/database_username/$MARIADB_USER/' /src/utils/config/eve-server.xml
-sed -i 's/database_password/$MARIADB_PASSWORD/' /src/utils/config/eve-server.xml
-sed -i 's/database_name/$MARIADB_DATABASE/' /src/utils/config/eve-server.xml
-sed -i's/database_port/$MARIADB_PORT/' /src/utils/config/eve-server.xml
+sed -i "s/database_host/$MARIADB_HOST/" /src/utils/config/eve-server.xml
+sed -i "s/database_username/$MARIADB_USER/" /src/utils/config/eve-server.xml
+sed -i "s/database_password/$MARIADB_PASSWORD/" /src/utils/config/eve-server.xml
+sed -i "s/database_name/$MARIADB_DATABASE/" /src/utils/config/eve-server.xml
+sed -i "s/database_port/$MARIADB_PORT/" /src/utils/config/eve-server.xml
 
 # Write evedb.yaml based upon above variables
 cd /src/sql

--- a/utils/container-scripts/db_init.sh
+++ b/utils/container-scripts/db_init.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
 
 # This is a script to populate the db container with the sql table data.
-# Author: James
+# Author: James, Gwen
 
-MARIADB_HOST=db
-MARIADB_DATABASE=evemu
-MARIADB_PASSWORD=evemu
-MARIADB_USER=evemu
+MARIADB_HOST="${MARIADB_HOST:-db}"
+MARIADB_DATABASE="${MARIADB_DATABASE:-evemu}"
+MARIADB_PASSWORD="${MARIADB_PASSWORD:-evemu}"
+MARIADB_USER="${MARIADB_USER:-evemu}"
+
 
 # Get script path:
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"

--- a/utils/container-scripts/db_init.sh
+++ b/utils/container-scripts/db_init.sh
@@ -16,7 +16,7 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 # Function to determine health of MariaDB container
 function waitContainer {
     #Checking if we can actually connect to the container
-    while ! mysql -h $MARIADB_HOST -u $MARIADB_USER -p$MARIADB_PASSWORD -e "use evemu;show tables;" >/dev/null 2>&1; do
+    while ! mysql -h $MARIADB_HOST -u $MARIADB_USER -p$MARIADB_PASSWORD -e "use $MARIADB_DATABASE;show tables;" >/dev/null 2>&1; do
         printf .
         sleep 1
     done

--- a/utils/container-scripts/db_init.sh
+++ b/utils/container-scripts/db_init.sh
@@ -7,7 +7,7 @@ MARIADB_HOST="${MARIADB_HOST:-db}"
 MARIADB_DATABASE="${MARIADB_DATABASE:-evemu}"
 MARIADB_PASSWORD="${MARIADB_PASSWORD:-evemu}"
 MARIADB_USER="${MARIADB_USER:-evemu}"
-MARIADB_PORT="${MARIADB_PORT:-3306}"
+MARIADB_PORT="${MARIADB_PORT:-'3306'}"
 
 
 # Get script path:
@@ -27,11 +27,11 @@ echo "Waiting for DB to start..."
 waitContainer evemu_db
 
 #Write the eve-server.xml variables
-sed 's/database_host/$MARIADB_HOST/' /src/utils/config/eve-server.xml
-sed 's/database_username/$MARIADB_USER/' /src/utils/config/eve-server.xml
-sed 's/database_password/$MARIADB_PASSWORD/' /src/utils/config/eve-server.xml
-sed 's/database_name/$MARIADB_DATABASE/' /src/utils/config/eve-server.xml
-sed 's/database_port/$MARIADB_PORT/' /src/utils/config/eve-server.xml
+sed -i 's/database_host/$MARIADB_HOST/' /src/utils/config/eve-server.xml
+sed -i 's/database_username/$MARIADB_USER/' /src/utils/config/eve-server.xml
+sed -i 's/database_password/$MARIADB_PASSWORD/' /src/utils/config/eve-server.xml
+sed -i 's/database_name/$MARIADB_DATABASE/' /src/utils/config/eve-server.xml
+sed -i's/database_port/$MARIADB_PORT/' /src/utils/config/eve-server.xml
 
 # Write evedb.yaml based upon above variables
 cd /src/sql


### PR DESCRIPTION
Adjusted the docker-compose and db_init.sh scripts to utilize environment variables for the MARIADB credentials. This allows for easier use of external db's and such.