### PR TITLE
Updates to Research Activity time calculations. (Plus minor fixes)

### DIFF
--- a/src/eve-common/utils/EvEMath.cpp
+++ b/src/eve-common/utils/EvEMath.cpp
@@ -65,14 +65,18 @@ int32 EvEMath::RAM::ProductionTime(uint32 BaseTime, float bpProductivityModifier
     return (BaseTime * effModifier * TimeModifier);
 }
 
-int32 EvEMath::RAM::ME_ResearchTime(uint32 BaseTime, uint8 MetallurgyLevel, float SlotModifier/*1*/, float ImplantModifier/*1*/ )
+const int LEVELMODIFIERS [11] = { 0, 105, 250, 595, 1414, 3360, 8000, 19000, 45255, 107700, 256000 }; // This probably needs to go to a more appropriate location
+
+int32 EvEMath::RAM::ME_ResearchTime(uint32 BaseTime, uint8 BlueprintLevel, int32 Runs, uint8 MetallurgyLevel, float SlotModifier/*1*/, float ImplantModifier/*1*/ )
 {
-    return (BaseTime * (13.0f - (0.05f * MetallurgyLevel)) * SlotModifier * ImplantModifier);
+    float LevelModifier = (LEVELMODIFIERS[Runs] / 105) - (LEVELMODIFIERS[BlueprintLevel] / 105);
+    return (BaseTime * (1.0f + (0.05f * MetallurgyLevel)) * SlotModifier * ImplantModifier * LevelModifier) / 13.0f; // Technically this 13 doesnt belong here however it makes the values more realistic based on the SDE crucible uses
 }
 
-int32 EvEMath::RAM::PE_ResearchTime(uint32 BaseTime, uint8 ResearchLevel, float SlotModifier/*1*/, float ImplantModifier/*1*/ )
+int32 EvEMath::RAM::PE_ResearchTime(uint32 BaseTime, uint8 BlueprintLevel, int32 Runs, uint8 ResearchLevel, float SlotModifier/*1*/, float ImplantModifier/*1*/ )
 {
-    return (BaseTime * (15.0f - (0.05f * ResearchLevel)) * SlotModifier * ImplantModifier);
+    float LevelModifier = (LEVELMODIFIERS[Runs] / 105) - (LEVELMODIFIERS[BlueprintLevel] / 105);
+    return (BaseTime * (1.0f + (0.05f * ResearchLevel)) * SlotModifier * ImplantModifier * LevelModifier) / 15.0f; // Technically this 15 doesnt belong here however it makes the values more realistic based on the SDE crucible uses
 }
 
 int32 EvEMath::RAM::RE_ResearchTime(uint32 BaseTime, uint8 ResearchLevel, float SlotModifier, float ImplantModifier)

--- a/src/eve-common/utils/EvEMath.cpp
+++ b/src/eve-common/utils/EvEMath.cpp
@@ -65,18 +65,23 @@ int32 EvEMath::RAM::ProductionTime(uint32 BaseTime, float bpProductivityModifier
     return (BaseTime * effModifier * TimeModifier);
 }
 
-const int LEVELMODIFIERS [11] = { 0, 105, 250, 595, 1414, 3360, 8000, 19000, 45255, 107700, 256000 }; // This probably needs to go to a more appropriate location
+float EvEMath::RAM::Research_LevelModifier(uint8 BlueprintLevel, int32 Runs)
+{
+    if (BlueprintLevel + Runs > 10){
+        return 0.0f;
+    }
+    const int LEVELMODIFIERS [11] = { 0, 105, 250, 595, 1414, 3360, 8000, 19000, 45255, 107700, 256000 };
+    return (LEVELMODIFIERS[Runs] / 105) - (LEVELMODIFIERS[BlueprintLevel] / 105);
+}
 
 int32 EvEMath::RAM::ME_ResearchTime(uint32 BaseTime, uint8 BlueprintLevel, int32 Runs, uint8 MetallurgyLevel, float SlotModifier/*1*/, float ImplantModifier/*1*/ )
 {
-    float LevelModifier = (LEVELMODIFIERS[Runs] / 105) - (LEVELMODIFIERS[BlueprintLevel] / 105);
-    return (BaseTime * (1.0f + (0.05f * MetallurgyLevel)) * SlotModifier * ImplantModifier * LevelModifier) / 13.0f; // Technically this 13 doesnt belong here however it makes the values more realistic based on the SDE crucible uses
+    return (BaseTime * (1.0f + (0.05f * MetallurgyLevel)) * SlotModifier * ImplantModifier * Research_LevelModifier(BlueprintLevel, Runs)) / 13.0f; // Technically this 13 doesnt belong here however it makes the values more realistic based on the SDE crucible uses
 }
 
 int32 EvEMath::RAM::PE_ResearchTime(uint32 BaseTime, uint8 BlueprintLevel, int32 Runs, uint8 ResearchLevel, float SlotModifier/*1*/, float ImplantModifier/*1*/ )
 {
-    float LevelModifier = (LEVELMODIFIERS[Runs] / 105) - (LEVELMODIFIERS[BlueprintLevel] / 105);
-    return (BaseTime * (1.0f + (0.05f * ResearchLevel)) * SlotModifier * ImplantModifier * LevelModifier) / 15.0f; // Technically this 15 doesnt belong here however it makes the values more realistic based on the SDE crucible uses
+    return (BaseTime * (1.0f + (0.05f * ResearchLevel)) * SlotModifier * ImplantModifier * Research_LevelModifier(BlueprintLevel, Runs)) / 15.0f; // Technically this 15 doesnt belong here however it makes the values more realistic based on the SDE crucible uses
 }
 
 int32 EvEMath::RAM::RE_ResearchTime(uint32 BaseTime, uint8 ResearchLevel, float SlotModifier, float ImplantModifier)

--- a/src/eve-common/utils/EvEMath.h
+++ b/src/eve-common/utils/EvEMath.h
@@ -41,6 +41,7 @@ namespace EvEMath {
         int32 PE_ResearchTime(uint32 BaseTime, uint8 BlueprintLevel, int32 Runs, uint8 ResearchLevel, float SlotModifier=1, float ImplantModifier=1);
         int32 RE_ResearchTime(uint32 BaseTime, uint8 ResearchLevel, float SlotModifier=1, float ImplantModifier=1);
 
+        float Research_LevelModifier(uint8 BlueprintLevel, int32 Runs);
         float ME_EffectOnWaste(float MaterialAmount, float BaseWasteFactor, float MaterialEfficiency);
         float ResearchPointsPerDay(float Multiplier, float AgentEffectiveQuality, uint8 CharSkillLevel, uint8 AgentSkillLevel );
 

--- a/src/eve-common/utils/EvEMath.h
+++ b/src/eve-common/utils/EvEMath.h
@@ -37,8 +37,8 @@ namespace EvEMath {
         int32 CopyTime(uint16 BaseTime, uint8 ScienceLevel, float SlotModifier=1, float ImplantModifier=1);
         int32 InventionTime(uint32 BaseTime, uint8 AdvLabLevel, float SlotModifier = 1, float ImplantModifier = 1);
         int32 ProductionTime(uint32 BaseTime, float bpProductivityModifier, float ProductionLevel, float TimeModifier=1);
-        int32 ME_ResearchTime(uint32 BaseTime, uint8 MetallurgyLevel, float SlotModifier=1, float ImplantModifier=1);
-        int32 PE_ResearchTime(uint32 BaseTime, uint8 ResearchLevel, float SlotModifier=1, float ImplantModifier=1);
+        int32 ME_ResearchTime(uint32 BaseTime, uint8 BlueprintLevel, int32 Runs, uint8 MetallurgyLevel, float SlotModifier=1, float ImplantModifier=1);
+        int32 PE_ResearchTime(uint32 BaseTime, uint8 BlueprintLevel, int32 Runs, uint8 ResearchLevel, float SlotModifier=1, float ImplantModifier=1);
         int32 RE_ResearchTime(uint32 BaseTime, uint8 ResearchLevel, float SlotModifier=1, float ImplantModifier=1);
 
         float ME_EffectOnWaste(float MaterialAmount, float BaseWasteFactor, float MaterialEfficiency);

--- a/src/eve-server/manufacturing/RamMethods.cpp
+++ b/src/eve-server/manufacturing/RamMethods.cpp
@@ -56,8 +56,18 @@ void RamMethods::ActivityCheck(Client* const pClient, const Call_InstallJob& arg
 
             pType = &bpRef->productType();
         } break;
-        case EvERam::Activity::ResearchMaterial:
+        case EvERam::Activity::ResearchMaterial: {
+            if (bpRef->mLevel() + args.runs > 10){
+                throw UserError ("RamActivityInvalid"); // The client should have a specific user error for this
+            }
+            if (bpRef->copy())
+                throw UserError ("RamCannotResearchABlueprintCopy");
+            pType = &bpRef->type();
+        } break;
         case EvERam::Activity::ResearchTime: {
+            if (bpRef->pLevel() + args.runs > 10){
+                throw UserError ("RamActivityInvalid"); // The client should have a specific user error for this
+            }
             if (bpRef->copy())
                 throw UserError ("RamCannotResearchABlueprintCopy");
             pType = &bpRef->type();
@@ -429,7 +439,7 @@ bool RamMethods::Calculate(const Call_InstallJob &args, BlueprintRef bpRef, Char
             pType = &bpRef->type();
             FactoryDB::GetMultipliers(args.AssemblyLineID, pType, into);
             into.productionTime = EvEMath::RAM::ME_ResearchTime(bpRef->type().researchMaterialTime(),
-                                                                bpRef->GetME(), args.runs,
+                                                                bpRef->mLevel(), args.runs,
                                                                 pChar->GetSkillLevel(EvESkill::Metallurgy), into.timeMultiplier
                                                                 /*implant modifier here*/);
             into.productionTime *= sConfig.ram.ResME;
@@ -441,7 +451,7 @@ bool RamMethods::Calculate(const Call_InstallJob &args, BlueprintRef bpRef, Char
             //ch->GetAttribute(AttrResearchCostPercent).get_int();   << this is not used
 
             into.productionTime = EvEMath::RAM::PE_ResearchTime(bpRef->type().researchProductivityTime(),
-                                                                bpRef->GetPE(), args.runs,
+                                                                bpRef->pLevel(), args.runs,
                                                                 pChar->GetSkillLevel(EvESkill::Research), into.timeMultiplier
                                                                 /*implant modifier here*/);
             into.productionTime *= sConfig.ram.ResPE;

--- a/src/eve-server/manufacturing/RamMethods.cpp
+++ b/src/eve-server/manufacturing/RamMethods.cpp
@@ -429,6 +429,7 @@ bool RamMethods::Calculate(const Call_InstallJob &args, BlueprintRef bpRef, Char
             pType = &bpRef->type();
             FactoryDB::GetMultipliers(args.AssemblyLineID, pType, into);
             into.productionTime = EvEMath::RAM::ME_ResearchTime(bpRef->type().researchMaterialTime(),
+                                                                bpRef->GetME(), args.runs,
                                                                 pChar->GetSkillLevel(EvESkill::Metallurgy), into.timeMultiplier
                                                                 /*implant modifier here*/);
             into.productionTime *= sConfig.ram.ResME;
@@ -440,6 +441,7 @@ bool RamMethods::Calculate(const Call_InstallJob &args, BlueprintRef bpRef, Char
             //ch->GetAttribute(AttrResearchCostPercent).get_int();   << this is not used
 
             into.productionTime = EvEMath::RAM::PE_ResearchTime(bpRef->type().researchProductivityTime(),
+                                                                bpRef->GetPE(), args.runs,
                                                                 pChar->GetSkillLevel(EvESkill::Research), into.timeMultiplier
                                                                 /*implant modifier here*/);
             into.productionTime *= sConfig.ram.ResPE;
@@ -478,7 +480,10 @@ bool RamMethods::Calculate(const Call_InstallJob &args, BlueprintRef bpRef, Char
     into.usageCost *= ceil(into.productionTime / 3600.0f);
     into.cost = into.installCost + into.usageCost;
     // multiply single run time by run count for total time
-    into.productionTime *= args.runs;
+    if (args.activityID != EvERam::Activity::ResearchMaterial && args.activityID != EvERam::Activity::ResearchTime) { // Dont multiply ME/PE activities as the time isnt linear.
+        into.productionTime *= args.runs;
+    }
+    
 
     into.maxJobStartTime = FactoryDB::GetNextFreeTime(args.AssemblyLineID);
 

--- a/src/eve-server/ship/modules/MiningLaser.cpp
+++ b/src/eve-server/ship/modules/MiningLaser.cpp
@@ -263,8 +263,10 @@ void MiningLaser::ProcessCycle(bool abort/*false*/)
         float unitVolume = oRef->GetAttribute(AttrVolume).get_float();
         float shipVolume = m_shipRef->GetMyInventory()->GetRemainingCapacity(m_holdFlag);
         float newQuantity = shipVolume / unitVolume;
-        oRef->SetQuantity(newQuantity, false);
-        oRef->MergeTypesInCargo(m_shipRef.get(), m_holdFlag);
+        if (newQuantity > 1) { // Catch situations where less than a whole unit would be added.
+            oRef->SetQuantity(newQuantity, false);
+            oRef->MergeTypesInCargo(m_shipRef.get(), m_holdFlag);
+        }
     }
 
     // add data to StatisticMgr


### PR DESCRIPTION
This update adds the level modifier system rather than each run of a ME or PE job always taking the same amount of time regardless of level.

- For now I've left a static divisor using the same value as the original code to keep the values realistic. The discrepancy is caused by the difference in the base value between the SDE used by Crucible compared to the current live SDE.
- Formula used pulled from https://eve-industry.org/export/IndustryFormulas.pdf which is whats currently used on live however I believe the same system was used back in Crucible

- Additionally added a minor bug fix for #182 where floats >0 but <1 were creating stacks of 0 ore in cargo.