### PR TITLE
Multiple minor fixes

### DIFF
--- a/src/eve-common/utils/EvEMath.cpp
+++ b/src/eve-common/utils/EvEMath.cpp
@@ -71,7 +71,7 @@ float EvEMath::RAM::Research_LevelModifier(uint8 BlueprintLevel, int32 Runs)
         return 0.0f;
     }
     const int LEVELMODIFIERS [11] = { 0, 105, 250, 595, 1414, 3360, 8000, 19000, 45255, 107700, 256000 };
-    return (LEVELMODIFIERS[Runs] / 105) - (LEVELMODIFIERS[BlueprintLevel] / 105);
+    return (LEVELMODIFIERS[BlueprintLevel + Runs] / 105) - (LEVELMODIFIERS[BlueprintLevel] / 105);
 }
 
 int32 EvEMath::RAM::ME_ResearchTime(uint32 BaseTime, uint8 BlueprintLevel, int32 Runs, uint8 MetallurgyLevel, float SlotModifier/*1*/, float ImplantModifier/*1*/ )

--- a/src/eve-server/manufacturing/RamMethods.cpp
+++ b/src/eve-server/manufacturing/RamMethods.cpp
@@ -110,8 +110,7 @@ void RamMethods::JobsCheck(Character* pChar, const Call_InstallJob& args)
 {
     if (args.activityID == EvERam::Activity::Manufacturing) {
         uint32 jobCount = FactoryDB::CountManufacturingJobs(pChar->itemID());
-        uint charMaxJobs = pChar->GetAttribute(AttrManufactureSlotLimit).get_int()
-                            + pChar->GetSkillLevel(EvESkill::MassProduction)
+        uint charMaxJobs = 1+ pChar->GetSkillLevel(EvESkill::MassProduction)
                             + pChar->GetSkillLevel(EvESkill::AdvancedMassProduction);
 
         if (charMaxJobs <= jobCount)
@@ -119,8 +118,7 @@ void RamMethods::JobsCheck(Character* pChar, const Call_InstallJob& args)
                     .AddAmount ("current", jobCount)
                     .AddAmount ("max", charMaxJobs);
     } else {
-        uint charMaxJobs = pChar->GetAttribute(AttrMaxLaborotorySlots).get_int()
-                            + pChar->GetSkillLevel(EvESkill::LaboratoryOperation)
+        uint charMaxJobs = 1+ pChar->GetSkillLevel(EvESkill::LaboratoryOperation)
                             + pChar->GetSkillLevel(EvESkill::AdvancedLaboratoryOperation);
 
         uint32 jobCount = FactoryDB::CountResearchJobs(pChar->itemID());

--- a/src/eve-server/ship/modules/ActiveModule.cpp
+++ b/src/eve-server/ship/modules/ActiveModule.cpp
@@ -291,7 +291,8 @@ void ActiveModule::Process()
     }
 
     // decrement repeat and check for single activation.
-    --m_repeat;
+    if (m_repeat < 999) // do not decrement as default allowing active modules to stay active for extended periods
+        --m_repeat;
     if (m_repeat < 1)
         m_Stop = true;
 


### PR DESCRIPTION
Minor fixes.

1. Amendment for #187 - Subtraction of level modifier on a already researched BPO was returning a negative value.
 Now calculates the total modifier then subtracts the already researched portion.

2. Fix for industry skills adding 2 slots per level rather than 1/level as intended.
Two potential fixes, Just the attribute (which includes skill bonuses) or the manual calc (which is easier to understand imo)
Went with the latter in this case.

3. Fix for #191 - Turns out the issue is actually caused by the ActiveModule repeat counter hitting zero (Modules deactivate after 1000s) which is not featured in the game.
Number of different ways to fix this one but I went with this one because it fixes all active modules rather than just mining lasers while maintaining the repeat function which is important for modules with single cycle limitations.