### PR TITLE
Fix: Planetary CC Deployment blocked by blank SovObject

### DIFF
--- a/src/eve-server/ship/ShipService.cpp
+++ b/src/eve-server/ship/ShipService.cpp
@@ -535,8 +535,8 @@ PyResult ShipBound::Handle_Drop(PyCallArgs &call)
                 //Code for spawning sovereignty structures
 
                 //Check if system is in empire space
-                SolarSystemData sysData;
-                sDataMgr.GetSolarSystemData(pClient->GetSystemID(), sysData);
+                SystemData sysData;
+                sDataMgr.GetSystemData(pClient->GetSystemID(), sysData);
                 if (sysData.factionID) {
                     pClient->SendErrorMsg("Launching sovereignty structures is forbidden in empire space.");
                     return nullptr;

--- a/src/eve-server/system/sov/SovereigntyDataMgr.cpp
+++ b/src/eve-server/system/sov/SovereigntyDataMgr.cpp
@@ -133,15 +133,10 @@ PyRep *SovereigntyDataMgr::GetSystemSovereignty(uint32 systemID)
     sDataMgr.GetSystemData(systemID, sysData);
 
     if (sysData.factionID)
-    { //If we have a factionID, we can set the system's sov data to it
-        args->SetItemString("contested", PyStatic.NewZero());
-        args->SetItemString("corporationID", PyStatic.NewZero());
-        args->SetItemString("claimTime", new PyLong(0));
-        args->SetItemString("claimStructureID", PyStatic.NewZero());
-        args->SetItemString("hubID", PyStatic.NewZero());
-        args->SetItemString("allianceID", new PyInt(sysData.factionID));
-        args->SetItemString("solarSystemID", new PyInt(systemID));
-        _log(SOV__INFO, "SovereigntyDataMgr::GetSystemSovereignty(): Faction system %u found, assigning factionID as allianceID.", systemID);
+    {   // If we have a factionID, the system is not claimable.
+        // We dont need to worry about FacWar Sov here, that is handled separately by Handle_GetSystemOccupier
+        _log(SOV__INFO, "SovereigntyDataMgr::GetSystemSovereignty(): Faction system %u found, Sending no SovData.", systemID);
+        return new PyNone();
     }
     else
     {
@@ -168,14 +163,9 @@ PyRep *SovereigntyDataMgr::GetSystemSovereignty(uint32 systemID)
         }
         else
         {
+            // No data means no claim, so we give 'None'
             _log(SOV__INFO, "SovereigntyDataMgr::GetSystemSovereignty(): No data for solarSystemID %u. Sending blank SovereigntyData object.", systemID);
-            args->SetItemString("contested", PyStatic.NewNone());
-            args->SetItemString("corporationID", PyStatic.NewNone());
-            args->SetItemString("claimTime", PyStatic.NewNone());
-            args->SetItemString("claimStructureID", PyStatic.NewNone());
-            args->SetItemString("hubID", PyStatic.NewNone());
-            args->SetItemString("allianceID", PyStatic.NewNone());
-            args->SetItemString("solarSystemID", new PyInt(systemID));
+            return new PyNone();
         }
     }
     return new PyObject("util.KeyVal", args);


### PR DESCRIPTION
Fix for #189 

"Blank" Sov Object is interpreted differently from a "None" Object.
This change allows CC's to be deployed in LS, HS and Unclaimed NS in addition to the standard NS claimed by the characters alliance.

@jdhirst This is for the issue I was talking about back in Feb, let me know if there's any issues I might have missed but functionally it works.