### PR TITLE
Allow server to be configured via .env vars

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,10 +15,10 @@ services:
     links:
       - "db"
     environment:
-      - SEED_MARKET=FALSE # Set to TRUE to seed the market when the server starts for the first time
-      - SEED_SATURATION=80 # Set saturation level of seed
-      - SEED_REGIONS=Derelik,The Citadel,The Forge # Define regions to be seeded
-      - RUN_WITH_GDB=FALSE #Set to TRUE to run evemu with gdb automatically
+      - SEED_MARKET=${SEED_MARKET:-FALSE} # Set to TRUE to seed the market when the server starts for the first time
+      - SEED_SATURATION=${SEED_SATURATION:-80} # Set saturation level of seed
+      - SEED_REGIONS=${SEED_REGIONS:-Derelik,The Citadel,The Forge} # Define regions to be seeded
+      - RUN_WITH_GDB=${RUN_GDB:-FALSE} #Set to TRUE to run evemu with gdb automatically
     stdin_open: true # Enables stdin for the container. Attach to it with 'docker attach'
     tty: true
     cap_add: #This is required for gdb to work


### PR DESCRIPTION
current server environment variables should be the same as the hardcoded vars from before, but moving them onto env vars with defaults allows server operators to set the options as needed without those options being overwritten on a server update. This also makes them easier to change when using popular docker tools like portainer to run the server.