### PR TITLE
Add define to workaround boost::asio::executor changes in Boost 1.74.0

### DIFF
--- a/src/eve-core/eve-core.h
+++ b/src/eve-core/eve-core.h
@@ -6,18 +6,19 @@
     Copyright 2006 - 2021 The EVEmu Team
     For the latest information visit https://evemu.dev
     ------------------------------------------------------------------------------------
-    This program is free software; you can redistribute it and/or modify it under
-    the terms of the GNU Lesser General Public License as published by the Free Software
-    Foundation; either version 2 of the License, or (at your option) any later
-    version.
+    This program is free software; you can redistribute it and/or modify it
+   under the terms of the GNU Lesser General Public License as published by the
+   Free Software Foundation; either version 2 of the License, or (at your
+   option) any later version.
 
     This program is distributed in the hope that it will be useful, but WITHOUT
-    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
-    FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
+   for more details.
 
-    You should have received a copy of the GNU Lesser General Public License along with
-    this program; if not, write to the Free Software Foundation, Inc., 59 Temple
-    Place - Suite 330, Boston, MA 02111-1307, USA, or go to
+    You should have received a copy of the GNU Lesser General Public License
+   along with this program; if not, write to the Free Software Foundation, Inc.,
+   59 Temple Place - Suite 330, Boston, MA 02111-1307, USA, or go to
     http://www.gnu.org/copyleft/lesser.txt.
     ------------------------------------------------------------------------------------
     Author:     Aim, Captnoord, Zhur, Bloody.Rabbit
@@ -31,20 +32,20 @@
 /* Header configuration                                                  */
 /*************************************************************************/
 #ifdef HAVE_CONFIG_H
-#   include "config.h"
+#include "config.h"
 #endif /* HAVE_CONFIG_H */
 
 #ifdef HAVE_CRTDBG_H
-#   define _CRTDBG_MAP_ALLOC 1
+#define _CRTDBG_MAP_ALLOC 1
 #endif /* HAVE_CRTDBG_H */
 
 #ifdef HAVE_INTTYPES_H
 // This requires some ugly tinkering because inttypes.h
 // is primarily a C header.
 // Pretend to be C99-compliant
-#   define __STDC_VERSION__     199901L
+#define __STDC_VERSION__ 199901L
 // We must "explicitly request" the format strings
-#   define __STDC_FORMAT_MACROS 1
+#define __STDC_FORMAT_MACROS 1
 #endif /* HAVE_INTTYPES_H */
 
 // Disable auto-linking of any Boost libraries
@@ -68,6 +69,8 @@
 
 // Standard Template Library includes
 #include <algorithm>
+#include <chrono>
+#include <functional>
 #include <iostream>
 #include <list>
 #include <map>
@@ -78,49 +81,47 @@
 #include <sstream>
 #include <stack>
 #include <string>
-#include <vector>
 #include <thread>
-#include <chrono>
-#include <functional>
 #include <tuple>
 #include <unordered_map>
 #include <unordered_set>
+#include <vector>
 
 #ifdef HAVE_CRTDBG_H
-#   include <crtdbg.h>
+#include <crtdbg.h>
 #endif /* HAVE_CRTDBG_H */
 
 #ifdef HAVE_INTTYPES_H
-#   include <inttypes.h>
+#include <inttypes.h>
 #endif /* HAVE_INTTYPES_H */
 
 #ifdef HAVE_SYS_STAT_H
-#   include <sys/stat.h>
+#include <sys/stat.h>
 #else /* !HAVE_SYS_STAT_H */
-#   include <io.h>
+#include <io.h>
 #endif /* !HAVE_SYS_STAT_H */
 
 #ifdef HAVE_SYS_TIME_H
-#   include <sys/time.h>
+#include <sys/time.h>
 #else /* !HAVE_SYS_TIME_H */
-#   include <sys/timeb.h>
+#include <sys/timeb.h>
 #endif /* !HAVE_SYS_TIME_H */
 
 #ifdef HAVE_VLD_H
-#   include <vld.h>
+#include <vld.h>
 #endif /* HAVE_VLD_H */
 
 /* *nix includes */
+#include <arpa/inet.h>
 #include <dirent.h>
-#include <pthread.h>
 #include <fcntl.h>
 #include <netdb.h>
-#include <arpa/inet.h>
 #include <netinet/in.h>
+#include <pthread.h>
 #include <sys/socket.h>
 
 #ifndef HAVE_ASINH
-#   include <boost/math/special_functions.hpp>
+#include <boost/math/special_functions.hpp>
 #endif /* !HAVE_ASINH */
 
 /************************************************************************/
@@ -129,19 +130,20 @@
 // Boost fails to build after 1.74.0 due to the issue described here:
 // https://stackoverflow.com/questions/65840258/boost-1-74-0-asio-executor-migration-issues
 // This #define is a supported workaround
+#include <boost/version.hpp>
 #if BOOST_VERSION >= 107400
 #define BOOST_ASIO_USE_TS_EXECUTOR_AS_DEFAULT 1
 #endif
 // Boost.Asio
 #include <boost/asio.hpp>
 // Gangsta
-#include <GaPreReqs.h>
 #include <GaMath.h>
+#include <GaPreReqs.h>
 #include <GaTypes.h>
 // MySQL
+#include <errmsg.h>
 #include <mysql.h>
 #include <mysqld_error.h>
-#include <errmsg.h>
 // TinyXML
 #include <tinyxml.h>
 // zlib
@@ -153,7 +155,7 @@
 /*  This code is designed to track and log memory leaks                  */
 /*************************************************************************/
 /* note...this code causes free() errors in xmlpacketgenerator.o */
-//#include "memory/mmgr.h"
+// #include "memory/mmgr.h"
 
 /* { backtrace, backtrace_symbols, backtrace_symbols_fd } header file.
  *  include this for DEBUG CODE ONLY!!
@@ -169,6 +171,5 @@
 #include "memory/SafeMem.h"
 // utils
 #include "utils/FastInt.h"
-
 
 #endif /* !__EVE_CORE_H__INCL__ */


### PR DESCRIPTION
eve-server fails to build with the following error when boost 1.74.0 or higher is installed, this workaround fixes the issue:
```
[ 64%] Building CXX object src/eve-server/CMakeFiles/eve-server.dir/inventory/InventoryBound.cpp.o
In file included from /usr/include/boost/asio/executor.hpp:342,
                 from /usr/include/boost/asio.hpp:99,
                 from /home/novafacing/hub/evemu_Crucible/src/eve-core/eve-core.h:130,
                 from /home/novafacing/hub/evemu_Crucible/src/eve-common/eve-common.h:33,
                 from /home/novafacing/hub/evemu_Crucible/src/eve-server/eve-server.h:33:
/usr/include/boost/asio/impl/executor.hpp: In instantiation of ‘void boost::asio::executor::impl< <template-parameter-1-1>, <template-parameter-1-2> >::on_work_started() [with Executor = boost::asio::any_io_executor; Allocator = std::allocator<void>]’:
/usr/include/boost/asio/impl/executor.hpp:76:8:   required from here
/usr/include/boost/asio/impl/executor.hpp:78:15: error: ‘class boost::asio::any_io_executor’ has no member named ‘on_work_started’
   78 |     executor_.on_work_started();
      |     ~~~~~~~~~~^~~~~~~~~~~~~~~
/usr/include/boost/asio/impl/executor.hpp: In instantiation of ‘void boost::asio::executor::impl< <template-parameter-1-1>, <template-parameter-1-2> >::on_work_finished() [with Executor = boost::asio::any_io_executor; Allocator = std::allocator<void>]’:
/usr/include/boost/asio/impl/executor.hpp:81:8:   required from here
/usr/include/boost/asio/impl/executor.hpp:83:15: error: ‘class boost::asio::any_io_executor’ has no member named ‘on_work_finished’
   83 |     executor_.on_work_finished();
      |     ~~~~~~~~~~^~~~~~~~~~~~~~~~
/usr/include/boost/asio/impl/executor.hpp: In instantiation of ‘void boost::asio::executor::impl< <template-parameter-1-1>, <template-parameter-1-2> >::dispatch(boost::asio::executor::function&&) [with Executor = boost::asio::any_io_executor; Allocator = std::allocator<void>; boost::asio::executor::function = boost::asio::detail::executor_function]’:
/usr/include/boost/asio/impl/executor.hpp:91:8:   required from here
/usr/include/boost/asio/impl/executor.hpp:93:15: error: ‘class boost::asio::any_io_executor’ has no member named ‘dispatch’
   93 |     executor_.dispatch(BOOST_ASIO_MOVE_CAST(function)(f), allocator_);
      |     ~~~~~~~~~~^~~~~~~~
/usr/include/boost/asio/impl/executor.hpp: In instantiation of ‘void boost::asio::executor::impl< <template-parameter-1-1>, <template-parameter-1-2> >::post(boost::asio::executor::function&&) [with Executor = boost::asio::any_io_executor; Allocator = std::allocator<void>; boost::asio::executor::function = boost::asio::detail::executor_function]’:
/usr/include/boost/asio/impl/executor.hpp:96:8:   required from here
/usr/include/boost/asio/impl/executor.hpp:98:15: error: ‘class boost::asio::any_io_executor’ has no member named ‘post’
   98 |     executor_.post(BOOST_ASIO_MOVE_CAST(function)(f), allocator_);
      |     ~~~~~~~~~~^~~~
/usr/include/boost/asio/impl/executor.hpp: In instantiation of ‘void boost::asio::executor::impl< <template-parameter-1-1>, <template-parameter-1-2> >::defer(boost::asio::executor::function&&) [with Executor = boost::asio::any_io_executor; Allocator = std::allocator<void>; boost::asio::executor::function = boost::asio::detail::executor_function]’:
/usr/include/boost/asio/impl/executor.hpp:101:8:   required from here
/usr/include/boost/asio/impl/executor.hpp:103:15: error: ‘class boost::asio::any_io_executor’ has no member named ‘defer’; did you mean ‘prefer’?
  103 |     executor_.defer(BOOST_ASIO_MOVE_CAST(function)(f), allocator_);
      |     ~~~~~~~~~~^~~~~
      |     prefer
make[2]: *** [src/eve-server/CMakeFiles/eve-server.dir/build.make:1622: src/eve-server/CMakeFiles/eve-server.dir/imageserver/ImageServerListener.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
```

Ref: https://stackoverflow.com/questions/65840258/boost-1-74-0-asio-executor-migration-issues