### PR TITLE
Fix for security status in character sheet not working

### DIFF
--- a/src/eve-server/standing/Standing.cpp
+++ b/src/eve-server/standing/Standing.cpp
@@ -95,7 +95,7 @@ PyResult Standing::GetMyKillRights(PyCallArgs &call) {
     return KillRights;
 }
 
-PyResult Standing::GetStandingTransactions(PyCallArgs &call, PyInt* fromID, PyInt* toID, PyInt* direction, PyInt* eventID, PyInt* eventType, PyLong* eventDateTime) {
+PyResult Standing::GetStandingTransactions(PyCallArgs &call, PyInt* fromID, PyInt* toID, PyInt* direction, std::optional<PyInt*> eventID, std::optional<PyInt*> eventType, std::optional<PyLong*> eventDateTime) {
     // data = sm.RemoteSvc('standing2').GetStandingTransactions(fromID, toID, direction, eventID, eventType, eventDateTime)
     _log(STANDING__MESSAGE,  "Standing::Handle_GetStandingTransactions()");
     call.Dump(STANDING__DUMP);

--- a/src/eve-server/standing/Standing.h
+++ b/src/eve-server/standing/Standing.h
@@ -49,7 +49,7 @@ protected:
     PyResult GetNPCNPCStandings(PyCallArgs& call);
     PyResult GetSecurityRating(PyCallArgs& call, PyInt* ownerID);
     PyResult GetMyKillRights(PyCallArgs& call);
-    PyResult GetStandingTransactions(PyCallArgs& call, PyInt* fromID, PyInt* toID, PyInt* direction, PyInt* eventID, PyInt* eventType, PyLong* eventDateTime);
+    PyResult GetStandingTransactions(PyCallArgs& call, PyInt* fromID, PyInt* toID, PyInt* direction, std::optional<PyInt*> eventID, std::optional<PyInt*> eventType, std::optional<PyLong*> eventDateTime);
     PyResult GetStandingCompositions(PyCallArgs& call, PyInt* fromID, PyInt* toID);
 };
 


### PR DESCRIPTION
Fixes https://github.com/EvEmu-Project/evemu_Crucible/issues/271

The last three arguments in the call from the character sheet are the issue, so adding std::optional looks to fix it. Since the method body does not use these parameters, it seemed safe to do, from looking at other code in this project.

I was able to successfully use these changes to open the character sheet and look at my standing & security status, along with being able to access the standing tab on the view info section of my character (the window that appears when you click on your portrait or another character's portrait), just to make sure that that still worked as expected.