### PR TITLE
Fix for character that has access to corp wallet being unable to buy

### DIFF
--- a/src/eve-server/market/MarketProxyService.cpp
+++ b/src/eve-server/market/MarketProxyService.cpp
@@ -62,7 +62,8 @@ MarketProxyService::MarketProxyService(EVEServiceManager& mgr) :
     this->Add("GetOrders", &MarketProxyService::GetOrders);
     this->Add("GetOldPriceHistory", &MarketProxyService::GetOldPriceHistory);
     this->Add("GetNewPriceHistory", &MarketProxyService::GetNewPriceHistory);
-    this->Add("PlaceCharOrder", &MarketProxyService::PlaceCharOrder);
+    this->Add("PlaceCharOrder", static_cast <PyResult (MarketProxyService::*)(PyCallArgs &call, PyInt*, PyInt*, PyFloat*, PyInt*, PyInt*, PyInt*, std::optional <PyInt*>, PyInt*, PyInt*, PyBool*, std::optional<PyRep*>)> (&MarketProxyService::PlaceCharOrder));
+    this->Add("PlaceCharOrder", static_cast <PyResult (MarketProxyService::*)(PyCallArgs &call, PyInt*, PyInt*, PyFloat*, PyInt*, PyInt*, PyInt*, std::optional <PyInt*>, PyInt*, PyInt*, PyInt*, std::optional<PyRep*>)> (&MarketProxyService::PlaceCharOrder));
     this->Add("GetCharOrders", &MarketProxyService::GetCharOrders);
     this->Add("ModifyCharOrder", &MarketProxyService::ModifyCharOrder);
     this->Add("CancelCharOrder", &MarketProxyService::CancelCharOrder);
@@ -527,6 +528,11 @@ PyResult MarketProxyService::PlaceCharOrder(PyCallArgs &call, PyInt* stationID, 
 
     //returns nothing.
     return nullptr;
+}
+
+PyResult MarketProxyService::PlaceCharOrder(PyCallArgs &call, PyInt* stationID, PyInt* typeID, PyFloat* price, PyInt* quantity, PyInt* bid, PyInt* orderRange, std::optional <PyInt*> itemID, PyInt* minVolume, PyInt* duration, PyInt* useCorp, std::optional<PyRep*> located) {
+    // Used when character has a corp wallet, client sends a PyInt instead of a PyBool
+    return PlaceCharOrder(call, stationID, typeID, price, quantity, bid, orderRange, itemID, minVolume, duration, new PyBool(useCorp->value()), located);
 }
 
 PyResult MarketProxyService::ModifyCharOrder(PyCallArgs &call, PyInt* orderID, PyFloat* newPrice, PyInt* bid, PyInt* stationID, PyInt* solarSystemID, PyFloat* price, PyInt* range, PyInt* volRemaining, PyLong* issueDate) {

--- a/src/eve-server/market/MarketProxyService.h
+++ b/src/eve-server/market/MarketProxyService.h
@@ -53,6 +53,7 @@ protected:
     PyResult CharGetNewTransactions(PyCallArgs& call, PyRep* sellBuy, PyRep* typeID, PyRep* clientID, PyRep* quantity, PyRep* fromDate, PyRep* maxPrice, PyRep* minPrice);
     PyResult GetOrders(PyCallArgs& call, PyInt* typeID);
     PyResult PlaceCharOrder(PyCallArgs& call, PyInt* stationID, PyInt* typeID, PyFloat* price, PyInt* quantity, PyInt* bid, PyInt* orderRange, std::optional <PyInt*> itemID, PyInt* minVolume, PyInt* duration, PyBool* useCorp, std::optional<PyRep*> located);
+    PyResult PlaceCharOrder(PyCallArgs &call, PyInt* stationID, PyInt* typeID, PyFloat* price, PyInt* quantity, PyInt* bid, PyInt* orderRange, std::optional <PyInt*> itemID, PyInt* minVolume, PyInt* duration, PyInt* useCorp, std::optional<PyRep*> located);
     PyResult ModifyCharOrder(PyCallArgs& call, PyInt* orderID, PyFloat* newPrice, PyInt* bid, PyInt* stationID, PyInt* solarSystemID, PyFloat* price, PyInt* range, PyInt* volRemaining, PyLong* issueDate);
     PyResult CancelCharOrder(PyCallArgs& call, PyInt* orderID, PyInt* regionID);
 


### PR DESCRIPTION
Fixes: https://github.com/EvEmu-Project/evemu_Crucible/issues/273

When a player tries to buy from the market and the character has a corp wallet, the client sends a PyInt instead of a PyBool to PlaceCharOrder for useCorp.

This PR adds a new function that handles receiving the int and calls the normal PlaceCharOrder function.

With these changes, I was able to successfully buy on a character in an npc corp and a character that has access to a corp wallet. I also tested trying to order with the corp wallet and got the message saying that Corp market transactions are not supported at this time, as expected.