### PR TITLE
Fix for GiveCash not working

### DIFF
--- a/src/eve-server/account/AccountService.h
+++ b/src/eve-server/account/AccountService.h
@@ -62,6 +62,9 @@ protected:
     PyResult GetJournalForAccounts(PyCallArgs& call, PyInt* accountKeys, PyLong* fromDate, std::optional<PyInt*> entryTypeID, PyInt* corpAccount, std::optional <PyInt*> transactionID, std::optional<PyInt*> rev);
     PyResult GiveCash(PyCallArgs& call, PyInt* toID, PyInt* amount, std::optional <PyWString*> reason);
     PyResult GiveCash(PyCallArgs& call, PyInt* toID, PyFloat* amount, std::optional <PyWString*> reason);
+    PyResult GiveCash(PyCallArgs& call, PyInt* toID, PyInt* amount, std::optional <PyString*> reason);
+    PyResult GiveCash(PyCallArgs& call, PyInt* toID, PyFloat* amount, std::optional <PyString*> reason);
+    PyResult GiveCash(PyCallArgs &call, PyInt* toID, PyFloat* amount, std::string reason);
     PyResult GiveCashFromCorpAccount(PyCallArgs& call, PyInt* toID, PyInt* amount, PyInt* fromAcctKey);
     PyResult GiveCashFromCorpAccount(PyCallArgs& call, PyInt* toID, PyFloat* amount, PyInt* fromAcctKey);
 };


### PR DESCRIPTION
Fixes a comment in https://github.com/EvEmu-Project/evemu_Crucible/issues/273

The GiveCash function (For both adding to a corp wallet and sending cash to another player) sends a PyString instead of a PyWString. I am unsure if this applies to all instances of GiveCash, so I've added support for both a PyString and PyWString.

I also was able to successfully test that I can send money to my corp, send money to a character, and that the reason shows up correctly (or shows No Reason Given).