### PR TITLE
Corporation workflow fixes

### DIFF
--- a/src/eve-server/corporation/CorpRegistryBound.cpp
+++ b/src/eve-server/corporation/CorpRegistryBound.cpp
@@ -1759,6 +1759,7 @@ PyResult CorpRegistryBound::GetOffices(PyCallArgs &call) {
     headers->AddItemString ("stationID");
     headers->AddItemString ("stationTypeID");
     headers->AddItemString ("officeFolderID");
+    headers->AddItemString ("typeID");
 
     if (this->m_offices == nullptr) {
         this->m_offices = new OfficeSparseBound (this->GetServiceManager (), *this, m_db, m_corpID, headers);

--- a/src/eve-server/corporation/CorpRegistryBound.cpp
+++ b/src/eve-server/corporation/CorpRegistryBound.cpp
@@ -1762,6 +1762,12 @@ PyResult CorpRegistryBound::GetOffices(PyCallArgs &call) {
     headers->AddItemString ("typeID");
 
     if (this->m_offices == nullptr) {
+        _log(CORP__CALL, "CorpRegistryBound::Handle_GetOffices() size=%lli m_offices nullptr", call.tuple->size());
+        this->m_offices = new OfficeSparseBound (this->GetServiceManager (), *this, m_db, m_corpID, headers);
+    } else {
+        _log(CORP__CALL, "CorpRegistryBound::Handle_GetOffices() size=%lli m_offices not nullptr", call.tuple->size());
+        this->m_offices = nullptr;
+        // Resetting m_offices because of server crash if more than one character is logged in and part of the same corp
         this->m_offices = new OfficeSparseBound (this->GetServiceManager (), *this, m_db, m_corpID, headers);
     }
 

--- a/src/eve-server/corporation/CorpRegistryBound.cpp
+++ b/src/eve-server/corporation/CorpRegistryBound.cpp
@@ -1480,7 +1480,7 @@ PyResult CorpRegistryBound::InsertApplication(PyCallArgs &call, PyInt* corporati
     return nullptr;
 }
 
-PyResult CorpRegistryBound::UpdateApplicationOffer(PyCallArgs &call, PyInt* characterID, PyRep* applicationText, PyInt* status, PyLong* applicationDateTime) {
+PyResult CorpRegistryBound::UpdateApplicationOffer(PyCallArgs &call, PyInt* characterID, PyRep* applicationText, PyInt* status, PyNone* applicationDateTime) {
     //     return self.GetCorpRegistry().UpdateApplicationOffer(characterID, applicationText, status, applicationDateTime = None) NOTE: time not used.
     _log(CORP__CALL, "CorpRegistryBound::Handle_UpdateApplicationOffer() size=%lli", call.tuple->size());
     call.Dump(CORP__CALL_DUMP);

--- a/src/eve-server/corporation/CorpRegistryBound.cpp
+++ b/src/eve-server/corporation/CorpRegistryBound.cpp
@@ -1762,12 +1762,6 @@ PyResult CorpRegistryBound::GetOffices(PyCallArgs &call) {
     headers->AddItemString ("typeID");
 
     if (this->m_offices == nullptr) {
-        _log(CORP__CALL, "CorpRegistryBound::Handle_GetOffices() size=%lli m_offices nullptr", call.tuple->size());
-        this->m_offices = new OfficeSparseBound (this->GetServiceManager (), *this, m_db, m_corpID, headers);
-    } else {
-        _log(CORP__CALL, "CorpRegistryBound::Handle_GetOffices() size=%lli m_offices not nullptr", call.tuple->size());
-        this->m_offices = nullptr;
-        // Resetting m_offices because of server crash if more than one character is logged in and part of the same corp
         this->m_offices = new OfficeSparseBound (this->GetServiceManager (), *this, m_db, m_corpID, headers);
     }
 

--- a/src/eve-server/corporation/CorpRegistryBound.h
+++ b/src/eve-server/corporation/CorpRegistryBound.h
@@ -47,7 +47,7 @@ protected:
     PyResult GetMyApplications(PyCallArgs& call);
     PyResult InsertApplication(PyCallArgs& call, PyInt* corporationID, PyRep* message);
     PyResult GetApplications(PyCallArgs& call);
-    PyResult UpdateApplicationOffer(PyCallArgs& call, PyInt* characterID, PyRep* applicationText, PyInt* status, PyLong* applicationDateTime);
+    PyResult UpdateApplicationOffer(PyCallArgs &call, PyInt* characterID, PyRep* applicationText, PyInt* status, PyNone* applicationDateTime);
     PyResult DeleteApplication(PyCallArgs& call, PyInt* corporationID, PyInt* characterID);
 
     PyResult UpdateDivisionNames(PyCallArgs& call,

--- a/src/eve-server/corporation/CorporationDB.cpp
+++ b/src/eve-server/corporation/CorporationDB.cpp
@@ -1929,10 +1929,11 @@ PyRep* CorporationDB::GetMemberTrackingInfo(uint32 corpID)
 
 PyRep* CorporationDB::GetMemberTrackingInfoSimple(uint32 corpID)
 {
+    // lastOnline may need something else more accurate, without lastOnline, the member list does not work for someone is a corp member
     DBQueryResult res;
     if (!sDatabase.RunQuery(res,
         "SELECT c.characterID, c.corporationID, c.logoffDateTime, c.logonDateTime, c.title, c.startDateTime, c.corpRole AS roles,"
-        " c.baseID, c.blockRoles, IFNULL(e.typeID, 0) AS shipTypeID"
+        " c.baseID, c.blockRoles, IFNULL(e.typeID, 0) AS shipTypeID, c.logonDateTime AS lastOnline"
         " FROM chrCharacters AS c"
         "  LEFT JOIN entity AS e ON e.itemID = c.shipID"
         " WHERE corporationID = %u", corpID))

--- a/src/eve-server/corporation/CorporationDB.cpp
+++ b/src/eve-server/corporation/CorporationDB.cpp
@@ -1224,7 +1224,7 @@ bool CorporationDB::FetchOfficesKeys (uint32 corporationID, DBQueryResult& res) 
 
 bool CorporationDB::FetchOffices (uint32 corpID, uint32 from, uint32 count, DBQueryResult& res) {
     return sDatabase.RunQuery(res,
-        "SELECT itemID, stationID, stationTypeID, officeFolderID"
+        "SELECT itemID, stationID, stationTypeID, officeFolderID, typeID"
         " FROM staOffices "
         " WHERE corporationID = %u "
         " LIMIT %u, %u ",

--- a/src/eve-server/services/SparseBound.h
+++ b/src/eve-server/services/SparseBound.h
@@ -87,7 +87,7 @@ public:
         this->m_primed = true;
     }
 
-    PyObject* GetHeader () { assert (this->m_primed); return this->m_header; }
+    PyObject* GetHeader () { assert (this->m_primed); PyIncRef(this->m_header); return this->m_header; }
 
     /**
      * Notifies the bound clients about a new row on the sparse rowset's data

--- a/src/eve-server/services/SparseBound.h
+++ b/src/eve-server/services/SparseBound.h
@@ -80,7 +80,7 @@ public:
         PyTuple* arguments = new PyTuple (3);
 
         arguments->SetItem (0, headers);
-        arguments->SetItem (1, new PySubStruct (new PySubStream (this->GetOID())));
+        arguments->SetItem (1, new PySubStruct (new PySubStream (boundServiceInformation)));
         arguments->SetItem (2, new PyInt (this->m_indexMap.size()));
 
         this->m_header = new PyObject ("util.SparseRowset", arguments);


### PR DESCRIPTION
This fixes a few things related to corporations. With it, now the corp window opens and loads correctly, and a corp application can be accepted.

- [Fix for corp window not opening](https://github.com/EvEmu-Project/evemu_Crucible/commit/e60d17958ab313c63b2ee0ae1e68ce373a3637d7) - Now the corp window in the UI loads and functionality is working from some basic tests. Based on https://discord.com/channels/165291219205881856/829517940184711168/1141481308774748192
- [Fix for GetOffices error when opening corp window](https://github.com/EvEmu-Project/evemu_Crucible/commit/b585009baea85e89a190bf7cc3dc1e88e4ffae8e) - An additional error was seen in the logs when opening the corp window, due to the typeID field being missing. Based on https://discord.com/channels/165291219205881856/829517940184711168/1141543224318644327
- [Fix for application offer response failing](https://github.com/EvEmu-Project/evemu_Crucible/commit/249d8b2f578293b147bde1451ad8f34b02e5ca78) - Handling an application was failing, due to the function signature not being correct, updated to match which seems to be fine.
- [Fix for server crash when more than one character logs in that are part of the same corp](https://github.com/EvEmu-Project/evemu_Crucible/pull/281/commits/4d87533e6caabd87ff91b31b12f8f903b25206cc) 
- [Fix for member list not showing when a corp member](https://github.com/d10sfan/evemu_Crucible/commit/3ba2baad70c881998ce8e05dbf54db6c50463ecd) - If someone is a corp member (not the creator of the corp), then the member list fails to load with this error - `AttributeError: 'blue.DBRow' object has no attribute 'lastOnline'`. This fixes that error so the member list loads. The db field used may need to be different, but now the member list loads in both cases.