### PR TITLE
Fixes for creating contracts

### DIFF
--- a/src/eve-server/character/CharMgrService.cpp
+++ b/src/eve-server/character/CharMgrService.cpp
@@ -42,7 +42,8 @@ CharMgrBound::CharMgrBound(EVEServiceManager& mgr, CharMgrService& parent, uint3
     m_containerFlag(contFlag)
 {
     this->Add("List", &CharMgrBound::List);
-    this->Add("ListStations", &CharMgrBound::ListStations);
+    this->Add("ListStations", static_cast <PyResult (CharMgrBound::*)(PyCallArgs&, PyInt*, PyBool*)> (&CharMgrBound::ListStations));
+    this->Add("ListStations", static_cast <PyResult (CharMgrBound::*)(PyCallArgs&, PyInt*, PyInt*)> (&CharMgrBound::ListStations));
     this->Add("ListStationItems", &CharMgrBound::ListStationItems);
     this->Add("ListStationBlueprintItems", &CharMgrBound::ListStationBlueprintItems);
 }
@@ -56,6 +57,11 @@ PyResult CharMgrBound::ListStationItems(PyCallArgs& call, PyInt* stationID)
 {
     // this is the assets window
     return CharacterDB::ListStationItems(m_ownerID, stationID->value());
+}
+
+PyResult CharMgrBound::ListStations(PyCallArgs& call, PyInt* blueprintOnly, PyBool* isCorporation)
+{
+  return ListStations(call, blueprintOnly, new PyInt(isCorporation->value()));
 }
 
 PyResult CharMgrBound::ListStations(PyCallArgs& call, PyInt* blueprintOnly, PyInt* isCorporation)

--- a/src/eve-server/character/CharMgrService.h
+++ b/src/eve-server/character/CharMgrService.h
@@ -87,6 +87,7 @@ public:
 
 protected:
     PyResult List(PyCallArgs& call);
+    PyResult ListStations(PyCallArgs& call, PyInt* blueprintOnly, PyBool* isCorporation);
     PyResult ListStations(PyCallArgs& call, PyInt* blueprintOnly, PyInt* isCorporation);
     PyResult ListStationItems(PyCallArgs& call, PyInt* stationID);
     PyResult ListStationBlueprintItems(PyCallArgs& call, PyInt* locationID, PyInt* stationID, PyInt* forCorporation);

--- a/src/eve-server/contract/ContractProxy.cpp
+++ b/src/eve-server/contract/ContractProxy.cpp
@@ -42,7 +42,12 @@ ContractProxy::ContractProxy () :
     Service("contractProxy")
 {
     this->Add("GetContract", &ContractProxy::GetContract);
-    this->Add("CreateContract", &ContractProxy::CreateContract);
+    this->Add("CreateContract", static_cast <PyResult(ContractProxy::*)(PyCallArgs &,PyInt*, PyBool*, std::optional <PyNone*>, PyInt*, PyInt*, PyInt*, std::optional<PyNone*>, PyInt*, PyInt*, PyInt*, PyString*, PyString*)> (&ContractProxy::CreateContract));
+    this->Add("CreateContract", static_cast <PyResult(ContractProxy::*)(PyCallArgs &,PyInt*, PyBool*, std::optional <PyInt*>, PyInt*, PyInt*, PyInt*, std::optional<PyNone*>, PyInt*, PyInt*, PyInt*, PyString*, PyString*)> (&ContractProxy::CreateContract));
+    this->Add("CreateContract", static_cast <PyResult(ContractProxy::*)(PyCallArgs &,PyInt*, PyBool*, std::optional <PyInt*>, PyInt*, PyInt*, PyInt*, std::optional<PyNone*>, PyInt*, PyInt*, PyInt*, PyWString*, PyString*)> (&ContractProxy::CreateContract));
+    this->Add("CreateContract", static_cast <PyResult(ContractProxy::*)(PyCallArgs &,PyInt*, PyBool*, std::optional <PyNone*>, PyInt*, PyInt*, PyInt*, std::optional<PyInt*>, PyInt*, PyInt*, PyInt*, PyString*, PyString*)> (&ContractProxy::CreateContract));
+    this->Add("CreateContract", static_cast <PyResult(ContractProxy::*)(PyCallArgs &,PyInt*, PyBool*, std::optional <PyNone*>, PyInt*, PyInt*, PyInt*, std::optional <PyNone*>, PyInt*, PyInt*, PyInt*, PyWString*,PyString*)> (&ContractProxy::CreateContract));
+    this->Add("CreateContract", static_cast <PyResult(ContractProxy::*)(PyCallArgs&, PyInt*, PyInt*, std::optional <PyInt*>, PyInt*, PyInt*, PyInt*, std::optional<PyInt*>, PyInt*, PyInt*, PyInt*, PyWString*, PyWString*)> (&ContractProxy::CreateContract));
     this->Add("DeleteContract", &ContractProxy::DeleteContract);
     this->Add("AcceptContract", &ContractProxy::AcceptContract);
     this->Add("CompleteContract", &ContractProxy::CompleteContract);
@@ -200,9 +205,40 @@ PyResult ContractProxy::SearchContracts(PyCallArgs &call) {
     }
 }
 
+PyResult ContractProxy::CreateContract(PyCallArgs &call,
+    PyInt* contractType, PyBool* isPrivate, std::optional <PyNone*> assigneeID, PyInt* expireTime, PyInt* duration, PyInt* startStationID, std::optional<PyNone*> endStationID,
+    PyInt* price, PyInt* reward, PyInt* collateral, PyString* title, PyString* description) {
+    return CreateContract(call, contractType, new PyInt(isPrivate->value()), std::nullopt, expireTime, duration, startStationID, std::nullopt, price, reward, collateral, new PyWString(title->content()), new PyWString(description->content()));
+}
+
+PyResult ContractProxy::CreateContract(PyCallArgs &call,
+    PyInt* contractType, PyBool* isPrivate, std::optional <PyInt*> assigneeID, PyInt* expireTime, PyInt* duration, PyInt* startStationID, std::optional<PyNone*> endStationID,
+    PyInt* price, PyInt* reward, PyInt* collateral, PyString* title, PyString* description) {
+    return CreateContract(call, contractType, new PyInt(isPrivate->value()), assigneeID, expireTime, duration, startStationID, std::nullopt, price, reward, collateral, new PyWString(title->content()), new PyWString(description->content()));
+}
+
+PyResult ContractProxy::CreateContract(PyCallArgs &call,
+    PyInt* contractType, PyBool* isPrivate, std::optional <PyInt*> assigneeID, PyInt* expireTime, PyInt* duration, PyInt* startStationID, std::optional<PyNone*> endStationID,
+    PyInt* price, PyInt* reward, PyInt* collateral, PyWString* title, PyString* description) {
+    return CreateContract(call, contractType, new PyInt(isPrivate->value()), assigneeID, expireTime, duration, startStationID, std::nullopt, price, reward, collateral, title, new PyWString(description->content()));
+}
+
+PyResult ContractProxy::CreateContract(PyCallArgs &call,
+    PyInt* contractType, PyBool* isPrivate, std::optional <PyNone*> assigneeID, PyInt* expireTime, PyInt* duration, PyInt* startStationID, std::optional<PyInt*> endStationID,
+    PyInt* price, PyInt* reward, PyInt* collateral, PyString* title, PyString* description) {
+    return CreateContract(call, contractType, new PyInt(isPrivate->value()), std::nullopt, expireTime, duration, startStationID, endStationID, price, reward, collateral, new PyWString(title->content()), new PyWString(description->content()));
+}
+
+PyResult ContractProxy::CreateContract(PyCallArgs &call,
+    PyInt* contractType, PyBool* isPrivate, std::optional <PyNone*> assigneeID, PyInt* expireTime, PyInt* duration, PyInt* startStationID, std::optional<PyNone*> endStationID,
+    PyInt* price, PyInt* reward, PyInt* collateral, PyWString* title, PyString* description) {
+    return CreateContract(call, contractType, new PyInt(isPrivate->value()), std::nullopt, expireTime, duration, startStationID, std::nullopt, price, reward, collateral, title, new PyWString(description->content()));
+}
+
+
 PyResult ContractProxy::CreateContract(PyCallArgs &call, 
     PyInt* contractType, PyInt* isPrivate, std::optional <PyInt*> assigneeID, PyInt* expireTime, PyInt* duration, PyInt* startStationID, std::optional<PyInt*> endStationID,
-    PyFloat* price, PyFloat* reward, PyFloat* collateral, PyWString* title, PyWString* description) {
+    PyInt* price, PyInt* reward, PyInt* collateral, PyWString* title, PyWString* description) {
     int startStationDivision, startSystemId, startRegionId, endSystemId, endRegionId;
     bool forCorp;
 

--- a/src/eve-server/contract/ContractProxy.cpp
+++ b/src/eve-server/contract/ContractProxy.cpp
@@ -877,7 +877,7 @@ PyResult ContractProxy::NumOutstandingContracts(PyCallArgs &call) {
     return nullptr;
 }
 
-PyResult ContractProxy::GetItemsInStation(PyCallArgs &call, PyInt* stationID) {
+PyResult ContractProxy::GetItemsInStation(PyCallArgs &call, PyInt* stationID, std::optional<PyInt*> forCorp) {
     uint32 station = call.tuple->GetItem(0)->AsInt()->value();
 
     if (sDataMgr.IsStation(stationID->value()) == false)

--- a/src/eve-server/contract/ContractProxy.h
+++ b/src/eve-server/contract/ContractProxy.h
@@ -41,7 +41,7 @@ protected:
     PyResult CompleteContract(PyCallArgs& call, PyInt* contractID, PyInt* completionStatus);
     PyResult DeleteContract(PyCallArgs& call, PyInt* contractID);
     PyResult NumOutstandingContracts(PyCallArgs& call);
-    PyResult GetItemsInStation(PyCallArgs& call, PyInt* stationID);
+    PyResult GetItemsInStation(PyCallArgs& call, PyInt* stationID, std::optional<PyInt*> forCorp);
     PyResult GetLoginInfo(PyCallArgs& call);
     PyResult SearchContracts(PyCallArgs& call);
     PyResult CollectMyPageInfo(PyCallArgs& call);

--- a/src/eve-server/contract/ContractProxy.h
+++ b/src/eve-server/contract/ContractProxy.h
@@ -35,7 +35,12 @@ public:
     ContractProxy();
 
 protected:
-    PyResult CreateContract(PyCallArgs& call, PyInt* contractType, PyInt* isPrivate, std::optional <PyInt*> assigneeID, PyInt* expireTime, PyInt* duration, PyInt* startStationID, std::optional<PyInt*> endStationID, PyFloat* price, PyFloat* reward, PyFloat* collateral, PyWString* title, PyWString* description);
+    PyResult CreateContract(PyCallArgs &call, PyInt* contractType, PyBool* isPrivate, std::optional <PyNone*> assigneeID, PyInt* expireTime, PyInt* duration, PyInt* startStationID, std::optional<PyNone*> endStationID, PyInt* price, PyInt* reward, PyInt* collateral, PyString* title, PyString* description);
+    PyResult CreateContract(PyCallArgs &call, PyInt* contractType, PyBool* isPrivate, std::optional <PyInt*> assigneeID, PyInt* expireTime, PyInt* duration, PyInt* startStationID, std::optional<PyNone*> endStationID, PyInt* price, PyInt* reward, PyInt* collateral, PyString* title, PyString* description);
+    PyResult CreateContract(PyCallArgs &call, PyInt* contractType, PyBool* isPrivate, std::optional <PyInt*> assigneeID, PyInt* expireTime, PyInt* duration, PyInt* startStationID, std::optional<PyNone*> endStationID, PyInt* price, PyInt* reward, PyInt* collateral, PyWString* title, PyString* description);
+    PyResult CreateContract(PyCallArgs &call, PyInt* contractType, PyBool* isPrivate, std::optional <PyNone*> assigneeID, PyInt* expireTime, PyInt* duration, PyInt* startStationID, std::optional<PyInt*> endStationID, PyInt* price, PyInt* reward, PyInt* collateral, PyString* title, PyString* description);
+    PyResult CreateContract(PyCallArgs &call, PyInt* contractType, PyBool* isPrivate, std::optional <PyNone*> assigneeID, PyInt* expireTime, PyInt* duration, PyInt* startStationID, std::optional<PyNone*> endStationID, PyInt* price, PyInt* reward, PyInt* collateral, PyWString* title, PyString* description);
+    PyResult CreateContract(PyCallArgs& call, PyInt* contractType, PyInt* isPrivate, std::optional <PyInt*> assigneeID, PyInt* expireTime, PyInt* duration, PyInt* startStationID, std::optional<PyInt*> endStationID, PyInt* price, PyInt* reward, PyInt* collateral, PyWString* title, PyWString* description);
     PyResult GetContract(PyCallArgs& call, PyInt* contractID);
     PyResult AcceptContract(PyCallArgs& call, PyInt* contractID);
     PyResult CompleteContract(PyCallArgs& call, PyInt* contractID, PyInt* completionStatus);


### PR DESCRIPTION
Fixes for the following issues related to creating contracts:

* Fix ListItemsInStation signature to allow for listing the items in station when creating a contract
* Add ListStations implementation that client was having issues with
* Add implementations for CreateContract, as parameters given differ depending on if it's a private contract versus public for example

This seems to be working well, as with the changes, I was able to create contacts with various settings (with and without descriptions, private vs public.

Not sure if there's a better way to handle the different arguments, as this needed lots of unique functions to catch the various ways that contracts are sent by the client.