### PR TITLE
Fixed asteroids being missing from bubble on reentry

### DIFF
--- a/src/eve-server/manufacturing/RamProxyService.cpp
+++ b/src/eve-server/manufacturing/RamProxyService.cpp
@@ -111,7 +111,7 @@ PyResult RamProxyService::AssemblyLinesSelect(PyCallArgs &call, PyString* filter
     return nullptr;
 }
 
-PyResult RamProxyService::GetJobs2(PyCallArgs &call, PyInt* ownerID, PyInt* completed) {
+PyResult RamProxyService::GetJobs2(PyCallArgs &call, PyInt* ownerID, PyBool* completed) {
     if (ownerID->value() == call.client->GetCorporationID())
         if ((call.client->GetCorpRole() & Corp::Role::FactoryManager) != Corp::Role::FactoryManager) {
             // what other roles (if any) can view corp factory jobs?

--- a/src/eve-server/manufacturing/RamProxyService.h
+++ b/src/eve-server/manufacturing/RamProxyService.h
@@ -35,7 +35,7 @@ public:
     RamProxyService();
 
 private:
-    PyResult GetJobs2(PyCallArgs& call, PyInt* ownerID, PyInt* completed);
+    PyResult GetJobs2(PyCallArgs& call, PyInt* ownerID, PyBool* completed);
     PyResult InstallJob(PyCallArgs& call, PyRep* locationData, PyRep* itemLocationData, PyRep* bomLocationData, PyRep* flagOutput, PyRep* buildRuns, PyRep* activityID, PyRep* licensedProductionRuns, PyRep* ownerFlag, PyRep* blah);
     PyResult CompleteJob(PyCallArgs& call, PyRep* info, PyRep* jobID, PyRep* cancel);
     PyResult AssemblyLinesGet(PyCallArgs& call, PyInt* stationID);

--- a/src/eve-server/pos/Structure.cpp
+++ b/src/eve-server/pos/Structure.cpp
@@ -193,7 +193,7 @@ void StructureItem::Rename(std::string name)
 }
 
 StructureSE::StructureSE(StructureItemRef structure, EVEServiceManager&services, SystemManager *system, const FactionData &data)
-    : DynamicSystemEntity(structure, services, system),
+    : ObjectSystemEntity(structure, services, system),
     m_moonSE(nullptr),
     m_planetSE(nullptr),
     m_towerSE(nullptr),

--- a/src/eve-server/pos/Structure.h
+++ b/src/eve-server/pos/Structure.h
@@ -97,7 +97,7 @@ class BatterySE;
 class WeaponSE;
 class ContainerSE;
 class StructureSE
-: public DynamicSystemEntity
+: public ObjectSystemEntity
 {
 public:
     StructureSE(StructureItemRef structure, EVEServiceManager& services, SystemManager* system, const FactionData& data);

--- a/src/eve-server/system/SystemBubble.cpp
+++ b/src/eve-server/system/SystemBubble.cpp
@@ -140,7 +140,6 @@ void SystemBubble::Process()
 //from the bubble and stuck into the vector for re-classification.
 void SystemBubble::ProcessWander(std::vector<SystemEntity*> &wanderers) {
     DynamicSystemEntity* pDSE(nullptr);
-    AsteroidSE* pASE(nullptr);
     std::map<uint32, SystemEntity*>::iterator itr = m_dynamicEntities.begin();
     while (itr != m_dynamicEntities.end()) {
         if (itr->second == nullptr) {
@@ -151,8 +150,9 @@ void SystemBubble::ProcessWander(std::vector<SystemEntity*> &wanderers) {
             ++itr;
             continue;
         }
-        pASE = itr->second->GetAsteroidSE(); // Check if dynamic entity is an Asteroid, GetDynamicSE() will be a nullptr as AsteroidSE objects are technically not dynamic entities.
-        if (pASE != nullptr) {
+        ObjectSystemEntity* pOSE(nullptr);
+        pOSE = itr->second->GetObjectSE(); // Check if dynamic entity is an ObjectSystemEntity and keep it loaded until we unload the system entirely.
+        if (pOSE != nullptr) {
             ++itr;
             continue;
         }

--- a/src/eve-server/system/SystemBubble.cpp
+++ b/src/eve-server/system/SystemBubble.cpp
@@ -140,6 +140,7 @@ void SystemBubble::Process()
 //from the bubble and stuck into the vector for re-classification.
 void SystemBubble::ProcessWander(std::vector<SystemEntity*> &wanderers) {
     DynamicSystemEntity* pDSE(nullptr);
+    AsteroidSE* pASE(nullptr);
     std::map<uint32, SystemEntity*>::iterator itr = m_dynamicEntities.begin();
     while (itr != m_dynamicEntities.end()) {
         if (itr->second == nullptr) {
@@ -147,6 +148,11 @@ void SystemBubble::ProcessWander(std::vector<SystemEntity*> &wanderers) {
             continue;
         }
         if (itr->second->IsWormholeSE()) {
+            ++itr;
+            continue;
+        }
+        pASE = itr->second->GetAsteroidSE(); // Check if dynamic entity is an Asteroid, GetDynamicSE() will be a nullptr as AsteroidSE objects are technically not dynamic entities.
+        if (pASE != nullptr) {
             ++itr;
             continue;
         }


### PR DESCRIPTION
Fix for issues #92 & #251

This was caused by m_dynamicEntities not having the asteroids populated on the second entry into the SystemBubble.
SystemBubble::ProcessWander was removing them because AsteroidSE objects are not a DynamicSystemEntity causing it to be erased from the map.
However, the BeltMgr and SystemManager will both refuse to re-add the roids to the bubble as they already exist.

I'm unsure if there is a better way to fix this or not but the simplest solution I found was just to explicitly check for roids and not erase them from the m_dynamicEntities map during the ProcessWander checks.