### PR TITLE
Vanilla Character Attributes and Skills reset

### DIFF
--- a/sql/migrations/20240614183142-charattributes.sql
+++ b/sql/migrations/20240614183142-charattributes.sql
@@ -1,0 +1,144 @@
+-- Fixed character attributes
+-- Removed outdated attributes from chrAncestries and chrBloodlines, adding them to chrAttributes as baseAttributes (PER 20 WIL 20 CHA 19 MEM 20 INT 20)
+
+
+-- +migrate Up
+ALTER TABLE chrAncestries
+    DROP COLUMN perception, 
+    DROP COLUMN willpower,
+    DROP COLUMN charisma,
+    DROP COLUMN memory, 
+    DROP COLUMN intelligence;
+
+ALTER TABLE chrBloodlines
+    DROP COLUMN perception, 
+    DROP COLUMN willpower,
+    DROP COLUMN charisma,
+    DROP COLUMN memory, 
+    DROP COLUMN intelligence;
+
+ALTER TABLE chrAttributes
+    ADD COLUMN baseAttribute TINYINT(3) UNSIGNED DEFAULT 20 AFTER attributeName;
+
+UPDATE chrAttributes
+    SET baseAttribute = 19 
+    WHERE attributeName = 'Charisma';
+
+-- +migrate Down
+
+-- Receate chrAncestries
+ALTER TABLE chrAttributes   
+    DROP COLUMN baseAttribute;
+
+CREATE TABLE tempAncestriesLeft AS
+	SELECT ancestryID, ancestryName, bloodlineID, description FROM chrAncestries;
+  
+CREATE TABLE tempAncestriesRight 
+	SELECT ancestryID, shortDescription, iconID, ancestryNameID, descriptionID, dataID FROM chrAncestries; 
+
+CREATE TABLE tempAncestriesCenter(
+    ancestryID INT(11) DEFAULT NULL,
+    perception TINYINT(3) DEFAULT NULL,
+    willpower TINYINT(3) DEFAULT NULL,
+    charisma TINYINT(3) DEFAULT NULL,
+    memory TINYINT(3) DEFAULT NULL,
+    intelligence TINYINT(3) DEFAULT NULL);
+
+INSERT INTO tempAncestriesCenter(ancestryID, perception, willpower, charisma, memory, intelligence) VALUES
+    (1,0,1,3,0,0),
+    (2,0,0,1,3,0),
+    (3,0,4,0,0,0),
+    (4,0,0,4,0,0),
+    (5,3,0,0,0,1),
+    (6,0,4,0,0,0),
+    (7,0,0,0,4,0),
+    (8,0,4,0,0,0),
+    (9,0,2,2,0,0),
+    (10,0,0,0,4,0),
+    (11,1,0,0,0,3),
+    (12,0,4,0,0,0),
+    (13,0,0,4,0,0),
+    (14,0,0,0,4,0),
+    (15,2,2,0,0,0),
+    (16,2,0,2,0,0),
+    (17,0,0,4,0,0),
+    (18,0,0,0,4,0),
+    (19,0,0,0,0,4),
+    (20,0,0,4,0,0),
+    (21,3,1,0,0,0),
+    (22,0,0,0,4,0),
+    (23,0,3,1,0,0),
+    (24,2,2,0,0,0),
+    (25,0,3,0,1,0),
+    (26,0,0,4,0,0),
+    (27,4,0,0,0,0),
+    (28,1,0,0,0,3),
+    (29,0,0,0,4,0),
+    (30,0,4,0,0,0),
+    (31,0,0,0,0,4),
+    (32,2,2,0,0,0),
+    (33,1,0,0,3,0),
+    (34,0,3,1,0,0),
+    (35,0,0,0,2,2),
+    (36,4,0,0,0,0),
+    (37,3,0,0,0,1),
+    (38,0,0,2,0,2),
+    (39,0,2,0,2,0),
+    (40,2,0,0,0,2),
+    (41,0,3,0,0,1),
+    (42,0,0,1,3,0);
+
+DROP TABLE chrAncestries;    
+
+CREATE TABLE chrAncestries AS
+SELECT L.*, C.perception, C.willpower, C.charisma, C.memory, C.intelligence, R.shortDescription, R.iconID, R.ancestryNameID, R.descriptionID, R.dataID 
+FROM tempAncestriesLeft L
+LEFT JOIN tempAncestriesCenter C ON L. ancestryID = C. ancestryID
+LEFT JOIN tempAncestriesRight R on L. ancestryID = R. ancestryID;
+
+DROP TABLE tempAncestriesLeft;
+DROP TABLE tempAncestriesCenter;
+DROP TABLE tempAncestriesRight;
+
+-- Receate chrBloodlines
+CREATE TABLE tempBloodlinesLeft AS
+	SELECT bloodlineID, bloodlineName, raceID, description, maleDescription, femaleDescription, shipTypeID, corporationID FROM chrBloodlines;
+  
+CREATE TABLE tempBloodlinesRight 
+	SELECT bloodlineID, shortDescription, shortMaleDescription, shortFemaleDescription, iconID, bloodlineNameID, descriptionID, dataID FROM chrBloodlines; 
+
+CREATE TABLE tempBloodlinesCenter(
+    bloodlineID INT(11) DEFAULT NULL,
+    perception TINYINT(3) DEFAULT NULL,
+    willpower TINYINT(3) DEFAULT NULL,
+    charisma TINYINT(3) DEFAULT NULL,
+    memory TINYINT(3) DEFAULT NULL,
+    intelligence TINYINT(3) DEFAULT NULL);
+
+INSERT INTO tempBloodlinesCenter(bloodlineID, perception, willpower, charisma, memory, intelligence) VALUES
+    (1,5,5,6,7,7),
+    (2,9,6,6,4,5),
+    (3,5,6,6,6,7),
+    (4,9,7,6,4,4),
+    (5,4,10,3,6,7),
+    (6,7,4,8,6,5),
+    (7,8,4,8,4,6),
+    (8,3,6,6,7,8),
+    (9,7,8,5,10,10),
+    (10,10,9,7,7,7),
+    (11,7,6,3,6,8),
+    (12,6,7,7,5,5),
+    (13,8,8,5,4,5),
+    (14,4,3,8,8,7);
+
+DROP TABLE chrBloodlines;    
+
+CREATE TABLE chrBloodlines AS
+SELECT L.*, C.perception, C.willpower, C.charisma, C.memory, C.intelligence, R.shortDescription, R.shortMaleDescription, R.shortFemaleDescription, R.iconID, R.bloodlineNameID, R.descriptionID, R.dataID
+FROM tempBloodlinesLeft L
+LEFT JOIN tempBloodlinesCenter C ON L.bloodlineID = C.bloodlineID
+LEFT JOIN tempBloodlinesRight R on L.bloodlineID = R.bloodlineID;
+
+DROP TABLE tempBloodlinesLeft;
+DROP TABLE tempBloodlinesCenter;
+DROP TABLE tempBloodlinesRight;

--- a/sql/migrations/20240614183142-charattributes.sql
+++ b/sql/migrations/20240614183142-charattributes.sql
@@ -1,5 +1,6 @@
--- Fixed character attributes
+-- Fixed character attributes to make them correct to vanilla Crucible
 -- Removed outdated attributes from chrAncestries and chrBloodlines, adding them to chrAttributes as baseAttributes (PER 20 WIL 20 CHA 19 MEM 20 INT 20)
+-- Fixed starting skills, job skills did not exist in Crucible
 
 
 -- +migrate Up

--- a/sql/migrations/20240621173914-skillsvanilla.sql
+++ b/sql/migrations/20240621173914-skillsvanilla.sql
@@ -1,0 +1,109 @@
+--  Fixed starting skills, job skills did not exist in Crucible
+
+-- +migrate Up
+
+-- UPDATE BASE SKILLS
+UPDATE sklBaseSkills
+    SET level = 2 WHERE skillTypeID = 3300; -- Gunnery
+UPDATE sklBaseSkills
+    SET level = 3 WHERE skillTypeID = 3327; -- Spaceship Command
+UPDATE sklBaseSkills
+    SET level = 2 WHERE skillTypeID = 3386; -- Mining
+UPDATE sklBaseSkills
+    SET level = 2 WHERE skillTypeID = 3393; -- Mechanics
+UPDATE sklBaseSkills
+    SET level = 3 WHERE skillTypeID = 3402; -- Science
+UPDATE sklBaseSkills
+    SET level = 3 WHERE skillTypeID = 3413; -- Engineering
+UPDATE sklBaseSkills
+    SET level = 3 WHERE skillTypeID = 3416; -- Shield Operation
+UPDATE sklBaseSkills
+    SET level = 3 WHERE skillTypeID = 3426; -- Electronics
+UPDATE sklBaseSkills
+    SET level = 3 WHERE skillTypeID = 3449; -- Navigation
+
+-- UPDATE RACE SKILLS
+DROP TABLE sklRaceSkills;
+CREATE TABLE sklRaceSkills(
+    id INT(10) DEFAULT NULL,
+    raceID INT(10) DEFAULT NULL,
+    skillTypeID INT(10) DEFAULT NULL,
+    level TINYINT(3) DEFAULT NULL
+);
+
+INSERT INTO sklRaceSkills(id, raceID, skillTypeID, level) VALUES
+    (1,1,3301,3),
+    (2,1,3330,2),
+    (3,2,3302,3),
+    (4,2,3329,2),
+    (5,4,3303,3),
+    (6,4,3331,2),
+    (7,8,3301,3),
+    (8,8,3328,2);
+
+-- +migrate Down
+
+-- RESTORE BASE SKILLS
+UPDATE sklBaseSkills
+    SET level = 2 WHERE skillTypeID = 3300; -- Gunnery
+UPDATE sklBaseSkills
+    SET level = 2 WHERE skillTypeID = 3327; -- Spaceship Command
+UPDATE sklBaseSkills
+    SET level = 1 WHERE skillTypeID = 3386; -- Mining
+UPDATE sklBaseSkills
+    SET level = 2 WHERE skillTypeID = 3393; -- Mechanics
+UPDATE sklBaseSkills
+    SET level = 1 WHERE skillTypeID = 3402; -- Science
+UPDATE sklBaseSkills
+    SET level = 2 WHERE skillTypeID = 3413; -- Engineering
+UPDATE sklBaseSkills
+    SET level = 1 WHERE skillTypeID = 3416; -- Shield Operation
+UPDATE sklBaseSkills
+    SET level = 2 WHERE skillTypeID = 3426; -- Electronics
+UPDATE sklBaseSkills
+    SET level = 2 WHERE skillTypeID = 3449; -- Navigation
+
+-- RESTORE RACE SKILLS
+DROP TABLE sklRaceSkills;
+CREATE TABLE sklRaceSkills(
+    id INT(10) DEFAULT NULL,
+    raceID INT(10) DEFAULT NULL,
+    skillTypeID INT(10) DEFAULT NULL,
+    level TINYINT(3) DEFAULT NULL
+);
+
+INSERT INTO sklRaceSkills(id, raceID, skillTypeID, level) VALUES
+    (1,1,3301,2),
+    (2,1,3330,2),
+    (3,1,3319,2),
+    (4,1,3321,3),
+    (5,1,3413,2),
+    (6,1,3432,1),
+    (7,1,3416,1),
+    (8,1,3426,2),
+    (9,1,21059,2),
+    (10,1,3425,1),
+    (11,2,3302,2),
+    (12,2,3329,2),
+    (13,2,3416,2),
+    (14,2,3413,2),
+    (15,2,3426,2),
+    (16,2,3300,2),
+    (17,2,3393,3),
+    (18,2,3394,4),
+    (19,4,3303,2),
+    (20,4,3331,2),
+    (21,4,3392,2),
+    (22,4,3393,3),
+    (23,4,3394,3),
+    (24,4,3417,2),
+    (25,4,3418,2),
+    (26,8,3301,2),
+    (27,8,3328,2),
+    (28,8,3436,4),
+    (29,8,3437,3),
+    (30,8,3442,2),
+    (31,8,12305,2),
+    (32,8,3392,2);
+
+

--- a/src/eve-server/cache/ObjCacheDB.cpp
+++ b/src/eve-server/cache/ObjCacheDB.cpp
@@ -777,10 +777,26 @@ PyRep *ObjCacheDB::Generate_invMetaTypes()
     return DBResultToCRowset(res);
 }
 
+
+/* OUTDATED VERSION: Uses old character attributes, which have been migrated to chrAttributes as baseAttribute. Uncomment to restore old functionality of race 
+and bloodline specific attributes. 
 PyRep *ObjCacheDB::Generate_chrBloodlines()
 {
     DBQueryResult res;
     const char *q = "SELECT bloodlineID, bloodlineName, raceID, description, maleDescription, femaleDescription, shipTypeID, corporationID, perception, willpower, charisma, memory, intelligence, shortDescription, shortMaleDescription, shortFemaleDescription, iconID, bloodlineNameID, descriptionID, dataID FROM chrBloodlines";
+    if (!sDatabase.RunQuery(res, q))
+    {
+        _log(DATABASE__ERROR, "Error in query for cached object 'config.Bloodlines': %s", res.error.c_str());
+        return nullptr;
+    }
+    return DBResultToPackedRowList(res);
+}
+*/
+
+PyRep *ObjCacheDB::Generate_chrBloodlines()
+{
+    DBQueryResult res;
+    const char *q = "SELECT bloodlineID, bloodlineName, raceID, description, maleDescription, femaleDescription, shipTypeID, corporationID, shortDescription, shortMaleDescription, shortFemaleDescription, iconID, bloodlineNameID, descriptionID, dataID FROM chrBloodlines";
     if (!sDatabase.RunQuery(res, q))
     {
         _log(DATABASE__ERROR, "Error in query for cached object 'config.Bloodlines': %s", res.error.c_str());
@@ -885,10 +901,25 @@ PyRep *ObjCacheDB::Generate_invContrabandTypes()
     return DBResultToCRowset(res);
 }
 
+/* OUTDATED VERSION: Uses old character attributes, which have been migrated to chrAttributes as baseAttribute. Uncomment to restore old functionality of race 
+and bloodline specific attributes. 
 PyRep *ObjCacheDB::Generate_c_chrBloodlines()
 {
     DBQueryResult res;
     const char *q = "SELECT bloodlineID, bloodlineName, raceID, description, maleDescription, femaleDescription, shipTypeID, corporationID, perception, willpower, charisma, memory, intelligence, shortDescription, shortMaleDescription, shortFemaleDescription, iconID, bloodlineNameID, descriptionID, dataID FROM chrBloodlines";
+    if (!sDatabase.RunQuery(res, q))
+    {
+        _log(DATABASE__ERROR, "Error in query for cached object 'charCreationInfo.bloodlines': %s", res.error.c_str());
+        return nullptr;
+    }
+    return DBResultToCRowset(res);
+}
+*/
+
+PyRep *ObjCacheDB::Generate_c_chrBloodlines()
+{
+    DBQueryResult res;
+    const char *q = "SELECT bloodlineID, bloodlineName, raceID, description, maleDescription, femaleDescription, shipTypeID, corporationID, shortDescription, shortMaleDescription, shortFemaleDescription, iconID, bloodlineNameID, descriptionID, dataID FROM chrBloodlines";
     if (!sDatabase.RunQuery(res, q))
     {
         _log(DATABASE__ERROR, "Error in query for cached object 'charCreationInfo.bloodlines': %s", res.error.c_str());
@@ -909,10 +940,25 @@ PyRep *ObjCacheDB::Generate_c_chrRaces()
     return DBResultToCRowset(res);
 }
 
+/* OUTDATED VERSION: Uses old character attributes, which have been migrated to chrAttributes as baseAttribute. Uncomment to restore old functionality of race 
+and bloodline specific attributes. 
 PyRep *ObjCacheDB::Generate_c_chrAncestries()
 {
     DBQueryResult res;
     const char *q = "SELECT ancestryID, ancestryName, bloodlineID, description, perception, willpower, charisma, memory, intelligence, iconID, iconID AS graphicID, shortDescription, ancestryNameID, descriptionID, dataID FROM chrAncestries";
+    if (!sDatabase.RunQuery(res, q))
+    {
+        _log(DATABASE__ERROR, "Error in query for cached object 'charCreationInfo.ancestries': %s", res.error.c_str());
+        return nullptr;
+    }
+    return DBResultToCRowset(res);
+}
+*/
+
+PyRep *ObjCacheDB::Generate_c_chrAncestries()
+{
+    DBQueryResult res;
+    const char *q = "SELECT ancestryID, ancestryName, bloodlineID, description, iconID, iconID AS graphicID, shortDescription, ancestryNameID, descriptionID, dataID FROM chrAncestries";
     if (!sDatabase.RunQuery(res, q))
     {
         _log(DATABASE__ERROR, "Error in query for cached object 'charCreationInfo.ancestries': %s", res.error.c_str());

--- a/src/eve-server/cache/ObjCacheDB.cpp
+++ b/src/eve-server/cache/ObjCacheDB.cpp
@@ -777,22 +777,6 @@ PyRep *ObjCacheDB::Generate_invMetaTypes()
     return DBResultToCRowset(res);
 }
 
-
-/* OUTDATED VERSION: Uses old character attributes, which have been migrated to chrAttributes as baseAttribute. Uncomment to restore old functionality of race 
-and bloodline specific attributes. 
-PyRep *ObjCacheDB::Generate_chrBloodlines()
-{
-    DBQueryResult res;
-    const char *q = "SELECT bloodlineID, bloodlineName, raceID, description, maleDescription, femaleDescription, shipTypeID, corporationID, perception, willpower, charisma, memory, intelligence, shortDescription, shortMaleDescription, shortFemaleDescription, iconID, bloodlineNameID, descriptionID, dataID FROM chrBloodlines";
-    if (!sDatabase.RunQuery(res, q))
-    {
-        _log(DATABASE__ERROR, "Error in query for cached object 'config.Bloodlines': %s", res.error.c_str());
-        return nullptr;
-    }
-    return DBResultToPackedRowList(res);
-}
-*/
-
 PyRep *ObjCacheDB::Generate_chrBloodlines()
 {
     DBQueryResult res;
@@ -901,21 +885,6 @@ PyRep *ObjCacheDB::Generate_invContrabandTypes()
     return DBResultToCRowset(res);
 }
 
-/* OUTDATED VERSION: Uses old character attributes, which have been migrated to chrAttributes as baseAttribute. Uncomment to restore old functionality of race 
-and bloodline specific attributes. 
-PyRep *ObjCacheDB::Generate_c_chrBloodlines()
-{
-    DBQueryResult res;
-    const char *q = "SELECT bloodlineID, bloodlineName, raceID, description, maleDescription, femaleDescription, shipTypeID, corporationID, perception, willpower, charisma, memory, intelligence, shortDescription, shortMaleDescription, shortFemaleDescription, iconID, bloodlineNameID, descriptionID, dataID FROM chrBloodlines";
-    if (!sDatabase.RunQuery(res, q))
-    {
-        _log(DATABASE__ERROR, "Error in query for cached object 'charCreationInfo.bloodlines': %s", res.error.c_str());
-        return nullptr;
-    }
-    return DBResultToCRowset(res);
-}
-*/
-
 PyRep *ObjCacheDB::Generate_c_chrBloodlines()
 {
     DBQueryResult res;
@@ -939,21 +908,6 @@ PyRep *ObjCacheDB::Generate_c_chrRaces()
     }
     return DBResultToCRowset(res);
 }
-
-/* OUTDATED VERSION: Uses old character attributes, which have been migrated to chrAttributes as baseAttribute. Uncomment to restore old functionality of race 
-and bloodline specific attributes. 
-PyRep *ObjCacheDB::Generate_c_chrAncestries()
-{
-    DBQueryResult res;
-    const char *q = "SELECT ancestryID, ancestryName, bloodlineID, description, perception, willpower, charisma, memory, intelligence, iconID, iconID AS graphicID, shortDescription, ancestryNameID, descriptionID, dataID FROM chrAncestries";
-    if (!sDatabase.RunQuery(res, q))
-    {
-        _log(DATABASE__ERROR, "Error in query for cached object 'charCreationInfo.ancestries': %s", res.error.c_str());
-        return nullptr;
-    }
-    return DBResultToCRowset(res);
-}
-*/
 
 PyRep *ObjCacheDB::Generate_c_chrAncestries()
 {

--- a/src/eve-server/character/CharUnboundMgrService.cpp
+++ b/src/eve-server/character/CharUnboundMgrService.cpp
@@ -278,15 +278,6 @@ PyResult CharUnboundMgrService::CreateCharacterWithDoll(PyCallArgs &call, PyRep*
         return PyStatic.NewZero();
     }
 
-    /* OUTDATED VERSION: Uses old character attributes, which have been migrated to chrAttributes as baseAttribute. Uncomment to restore old functionality of race 
-     * and bloodline specific attributes. 
-     * if (!CharacterDB::GetAttributesFromAncestry(cdata.ancestryID, intelligence, charisma, perception, memory, willpower)) {
-     *   _log(CLIENT__ERROR, "Failed to load char create details. Bloodline %u, ancestry %u.", char_type->bloodlineID(), cdata.ancestryID);
-     *   sItemFactory.UnsetUsingClient();
-     *   return PyStatic.NewZero();
-     * }
-     */
-   
     // triple attributes and save
     uint8 multiplier = sConfig.character.statMultiplier;
     charRef->SetAttribute(AttrIntelligence, intelligence * multiplier, false);
@@ -310,13 +301,6 @@ PyResult CharUnboundMgrService::CreateCharacterWithDoll(PyCallArgs &call, PyRep*
              char_type->bloodlineID(), cdata.ancestryID);
         // dont really care if this fails.  not enough to deny creation ...maybe make error?
     }
-
-	/* OUTDATED: Career skills not used in Crucible. Uncomment to restore old functionality.
-        //  Career Skills
-    if (!CharacterDB::GetSkillsByCareer(cdata.careerID, startingSkills)) {
-        _log(CLIENT__ERROR, "Failed to load char Career skills for %u.", cdata.careerSpecialityID);
-        // dont really care if this fails.  not enough to deny creation ...maybe make error?
-    } */
 
     //spawn all the skills
     uint8 skillLevel = 0;

--- a/src/eve-server/character/CharUnboundMgrService.cpp
+++ b/src/eve-server/character/CharUnboundMgrService.cpp
@@ -272,11 +272,21 @@ PyResult CharUnboundMgrService::CreateCharacterWithDoll(PyCallArgs &call, PyRep*
         cpor.Build(charRef->itemID(), portraitInfoData);
 
     // query attribute bonuses from ancestry
-    if (!CharacterDB::GetAttributesFromAncestry(cdata.ancestryID, intelligence, charisma, perception, memory, willpower)) {
-        _log(CLIENT__ERROR, "Failed to load char create details. Bloodline %u, ancestry %u.", char_type->bloodlineID(), cdata.ancestryID);
+     if (!CharacterDB::GetAttributesFromAttributes(intelligence, charisma, perception, memory, willpower)) {
+        _log(CLIENT__ERROR, "Failed to load char attributes.");
         sItemFactory.UnsetUsingClient();
         return PyStatic.NewZero();
     }
+
+    /* OUTDATED VERSION: Uses old character attributes, which have been migrated to chrAttributes as baseAttribute. Uncomment to restore old functionality of race 
+     * and bloodline specific attributes. 
+     * if (!CharacterDB::GetAttributesFromAncestry(cdata.ancestryID, intelligence, charisma, perception, memory, willpower)) {
+     *   _log(CLIENT__ERROR, "Failed to load char create details. Bloodline %u, ancestry %u.", char_type->bloodlineID(), cdata.ancestryID);
+     *   sItemFactory.UnsetUsingClient();
+     *   return PyStatic.NewZero();
+     * }
+     */
+   
     // triple attributes and save
     uint8 multiplier = sConfig.character.statMultiplier;
     charRef->SetAttribute(AttrIntelligence, intelligence * multiplier, false);

--- a/src/eve-server/character/CharUnboundMgrService.cpp
+++ b/src/eve-server/character/CharUnboundMgrService.cpp
@@ -310,11 +310,13 @@ PyResult CharUnboundMgrService::CreateCharacterWithDoll(PyCallArgs &call, PyRep*
              char_type->bloodlineID(), cdata.ancestryID);
         // dont really care if this fails.  not enough to deny creation ...maybe make error?
     }
-	//  Career Skills
+
+	/* OUTDATED: Career skills not used in Crucible. Uncomment to restore old functionality.
+        //  Career Skills
     if (!CharacterDB::GetSkillsByCareer(cdata.careerID, startingSkills)) {
         _log(CLIENT__ERROR, "Failed to load char Career skills for %u.", cdata.careerSpecialityID);
         // dont really care if this fails.  not enough to deny creation ...maybe make error?
-    }
+    } */
 
     //spawn all the skills
     uint8 skillLevel = 0;

--- a/src/eve-server/character/CharacterDB.cpp
+++ b/src/eve-server/character/CharacterDB.cpp
@@ -1125,40 +1125,7 @@ bool CharacterDB::ChangeCloneLocation(uint32 characterID, uint32 locationID)
     return true;
 }
 
-/* OUTDATED VERSION: Uses old character attributes, which have been migrated to chrAttributes as baseAttribute. Uncomment to restore old functionality of race 
-and bloodline specific attributes. New version is below as GetAttributesFromAttributes
-
-bool CharacterDB::GetAttributesFromAncestry(uint32 ancestryID, uint8 &intelligence, uint8 &charisma, uint8 &perception, uint8 &memory, uint8 &willpower) {
-    DBQueryResult res;
-
-    if (!sDatabase.RunQuery(res,
-        " SELECT "
-        "  intelligence, charisma, perception, memory, willpower "
-        " FROM chrAncestries "
-        " WHERE ancestryID = %u ", ancestryID))
-    {
-        codelog(DATABASE__ERROR, "Error in query: %s", res.error.c_str());
-        return (false);
-    }
-
-    DBResultRow row;
-    if (!res.GetRow(row)) {
-        codelog(DATABASE__ERROR, "Failed to find ancestry information for ancestry %u", ancestryID);
-        return false;
-    }
-
-    intelligence += row.GetUInt(0);
-    charisma += row.GetUInt(1);
-    perception += row.GetUInt(2);
-    memory += row.GetUInt(3);
-    willpower += row.GetUInt(4);
-
-    return (true);
-} 
- */
-
 bool CharacterDB::GetAttributesFromAttributes(uint8 &intelligence, uint8 &charisma, uint8 &perception, uint8 &memory, uint8 &willpower) {
-
     DBQueryResult res;
 
     if (!sDatabase.RunQuery(res,
@@ -1171,9 +1138,8 @@ bool CharacterDB::GetAttributesFromAttributes(uint8 &intelligence, uint8 &charis
     }
         
     for(int i = 0; i < res.GetRowCount(); i++){
-
         DBResultRow row;
-        uint32 attributeID;
+        uint32 attributeID = 0;
 
         if (!res.GetRow(row)) {
         codelog(DATABASE__ERROR, "Failed to find attribute information for attribute %d", attributeID);
@@ -1207,7 +1173,6 @@ bool CharacterDB::GetAttributesFromAttributes(uint8 &intelligence, uint8 &charis
     
     return (true);
 }
-
 
 bool CharacterDB::GetCareerBySchool(uint32 schoolID, uint8 &raceID, uint32 &careerID) {
     DBQueryResult res;
@@ -2098,12 +2063,6 @@ bool CharacterDB::GetCharacterType(uint8 bloodlineID, CharacterTypeData &into) {
         "  maleDescription,"
         "  femaleDescription,"
         "  corporationID,"
-        //OUTDATED
-        //"  perception,"
-        //"  willpower,"
-        //"  charisma,"
-        //"  memory,"
-        //"  intelligence,"
         "  shortDescription,"
         "  shortMaleDescription,"
         "  shortFemaleDescription "

--- a/src/eve-server/character/CharacterDB.cpp
+++ b/src/eve-server/character/CharacterDB.cpp
@@ -1125,6 +1125,9 @@ bool CharacterDB::ChangeCloneLocation(uint32 characterID, uint32 locationID)
     return true;
 }
 
+/* OUTDATED VERSION: Uses old character attributes, which have been migrated to chrAttributes as baseAttribute. Uncomment to restore old functionality of race 
+and bloodline specific attributes. New version is below as GetAttributesFromAttributes
+
 bool CharacterDB::GetAttributesFromAncestry(uint32 ancestryID, uint8 &intelligence, uint8 &charisma, uint8 &perception, uint8 &memory, uint8 &willpower) {
     DBQueryResult res;
 
@@ -1151,7 +1154,60 @@ bool CharacterDB::GetAttributesFromAncestry(uint32 ancestryID, uint8 &intelligen
     willpower += row.GetUInt(4);
 
     return (true);
+} 
+ */
+
+bool CharacterDB::GetAttributesFromAttributes(uint8 &intelligence, uint8 &charisma, uint8 &perception, uint8 &memory, uint8 &willpower) {
+
+    DBQueryResult res;
+
+    if (!sDatabase.RunQuery(res,
+        " SELECT "
+        "  attributeID, baseAttribute "
+        " FROM chrAttributes "))
+    {
+        codelog(DATABASE__ERROR, "Error in query: %s", res.error.c_str());
+        return (false);
+    }
+        
+    for(int i = 0; i < res.GetRowCount(); i++){
+
+        DBResultRow row;
+        uint32 attributeID;
+
+        if (!res.GetRow(row)) {
+        codelog(DATABASE__ERROR, "Failed to find attribute information for attribute %d", attributeID);
+            return false;
+        }
+
+        attributeID = row.GetUInt(0);
+
+        switch (attributeID)
+        {
+        case (uint32)1:
+            intelligence += row.GetUInt(1);
+            break;
+        case (uint32)2:
+            charisma += row.GetUInt(1);
+            break;
+        case (uint32)3:
+            perception += row.GetUInt(1);
+            break;
+        case (uint32)4:
+            memory += row.GetUInt(1);
+            break;
+        case (uint32)5:
+            willpower += row.GetUInt(1);
+            break;
+        default:
+            codelog(DATABASE__ERROR, "Unknown attribute %d", attributeID); 
+            break;
+        }
+    }
+    
+    return (true);
 }
+
 
 bool CharacterDB::GetCareerBySchool(uint32 schoolID, uint8 &raceID, uint32 &careerID) {
     DBQueryResult res;
@@ -2042,11 +2098,12 @@ bool CharacterDB::GetCharacterType(uint8 bloodlineID, CharacterTypeData &into) {
         "  maleDescription,"
         "  femaleDescription,"
         "  corporationID,"
-        "  perception,"
-        "  willpower,"
-        "  charisma,"
-        "  memory,"
-        "  intelligence,"
+        //OUTDATED
+        //"  perception,"
+        //"  willpower,"
+        //"  charisma,"
+        //"  memory,"
+        //"  intelligence,"
         "  shortDescription,"
         "  shortMaleDescription,"
         "  shortFemaleDescription "
@@ -2070,14 +2127,9 @@ bool CharacterDB::GetCharacterType(uint8 bloodlineID, CharacterTypeData &into) {
     into.maleDescription = row.GetText(3);
     into.femaleDescription = row.GetText(4);
     into.corporationID = row.GetUInt(5);
-    into.perception = row.GetUInt(6);
-    into.willpower = row.GetUInt(7);
-    into.charisma = row.GetUInt(8);
-    into.memory = row.GetUInt(9);
-    into.intelligence = row.GetUInt(10);
-    into.shortDescription = row.GetText(11);
-    into.shortMaleDescription = row.GetText(12);
-    into.shortFemaleDescription = row.GetText(13);
+    into.shortDescription = row.GetText(6);
+    into.shortMaleDescription = row.GetText(7);
+    into.shortFemaleDescription = row.GetText(8);
     return true;
 }
 

--- a/src/eve-server/character/CharacterDB.h
+++ b/src/eve-server/character/CharacterDB.h
@@ -159,8 +159,13 @@ public:
      * @param[out] willpower Bonus to willpower.
      * @return True if operation succeeded, false if failed.
      */
-    static bool        GetAttributesFromAncestry(uint32 ancestryID, uint8 &intelligence, uint8 &charisma, uint8 &perception, uint8 &memory, uint8 &willpower);
 
+
+    /* OUTDATED, new below
+     * static bool        GetAttributesFromAncestry(uint32 ancestryID, uint8 &intelligence, uint8 &charisma, uint8 &perception, uint8 &memory, uint8 &willpower); 
+     */
+    static bool        GetAttributesFromAttributes(uint8 &intelligence, uint8 &charisma, uint8 &perception, uint8 &memory, uint8 &willpower);
+   
     static bool        GetBaseSkills(std::map< uint32, uint8 >& into);
     static bool        GetSkillsByRace(uint32 raceID, std::map< uint32, uint8 >& into);
     static bool        GetSkillsByCareer(uint32 careerID, std::map< uint32, uint8 >& into);

--- a/src/eve-server/character/CharacterDB.h
+++ b/src/eve-server/character/CharacterDB.h
@@ -160,10 +160,6 @@ public:
      * @return True if operation succeeded, false if failed.
      */
 
-
-    /* OUTDATED, new below
-     * static bool        GetAttributesFromAncestry(uint32 ancestryID, uint8 &intelligence, uint8 &charisma, uint8 &perception, uint8 &memory, uint8 &willpower); 
-     */
     static bool        GetAttributesFromAttributes(uint8 &intelligence, uint8 &charisma, uint8 &perception, uint8 &memory, uint8 &willpower);
    
     static bool        GetBaseSkills(std::map< uint32, uint8 >& into);

--- a/utils/config/eve-server.xml
+++ b/utils/config/eve-server.xml
@@ -143,13 +143,13 @@ boolean can use either 0/1 OR true/false.
     </bpTimes>
 
     <character>
-        <startBalance>600000000.0</startBalance>
+        <startBalance>5000.0</startBalance>
         <startAurBalance>600.0</startAurBalance>
         <startStation>0</startStation><!-- stationID of character starting station.  '0' to use default based on race -->
         <startSecRating>1.0</startSecRating>
         <startCorporation>0</startCorporation><!-- corporationID for new characters '0' to use default based on school -->
         <terminationDelay>1800</terminationDelay> <!-- seconds  30m default -->
-        <statMultiplier>3</statMultiplier><!-- stats are multiplied by this (after remap) -->
+        <statMultiplier>1</statMultiplier><!-- stats are multiplied by this (after remap) -->
         <allow3edChar>false</allow3edChar><!-- (dis)allow creating a third character -->
     </character>
 


### PR DESCRIPTION
This PR aligns the character attributes and starting skills with vanilla Crucible values to create a more accurate and vanilla experience. I used historical sources to find the starting values for skills, attributes, and ISK. All changes were non-destructive to allow for reversion. There are 2 new database migrations and changes to several server classes and eve-server.xml. 

A new character will now start with:
20 Perception
19 Charisma
20 Intelligence
20 Memory
20 Willpower

~60K SP
5,000 ISK


Reference: Eve University "Starting Skills" of 23 March 2013 
[https://wiki.eveuniversity.org/index.php?title=Starting_skills&direction=next&oldid=13906](url)

I am investigating the difference between the quoted 56,489 SP value and the resulting value due to these changes.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request updates character attributes and starting skills to match vanilla Crucible values. It includes new database migrations and modifications to server classes to support these changes. The changes are non-destructive, allowing for easy reversion if needed.

- **New Features**:
    - Introduced new character attributes and starting skills aligned with vanilla Crucible values.
- **Enhancements**:
    - Replaced outdated character attribute retrieval methods with new methods using base attributes.
    - Updated database schema to remove old attributes from chrAncestries and chrBloodlines, and added them to chrAttributes as baseAttributes.

<!-- Generated by sourcery-ai[bot]: end summary -->