### PR TITLE
Fix 'both' filter in wallet transactions view

### DIFF
--- a/src/eve-server/market/MarketDB.cpp
+++ b/src/eve-server/market/MarketDB.cpp
@@ -351,12 +351,15 @@ PyRep *MarketDB::GetTransactions(uint32 clientID, Market::TxData& data) {
         typeID = "AND typeID=";
         typeID += std::to_string(data.typeID);
     }
+
     std::string buy = "";
     if (data.isBuy > -1) {
         buy = "AND transactionType=";
         buy += std::to_string(data.isBuy);
     }
+
     DBQueryResult res;
+
     if (!sDatabase.RunQuery(res,
         "SELECT"
         "   transactionID, transactionDate, typeID, keyID, quantity, price,"
@@ -365,8 +368,8 @@ PyRep *MarketDB::GetTransactions(uint32 clientID, Market::TxData& data) {
         " WHERE clientID=%u %s AND quantity>=%u AND price>=%.2f AND "
         " transactionDate>=%lli %s AND keyID=%u AND characterID=%u",
         clientID, typeID.c_str(), data.quantity, data.price,
-        data.time, buy.c_str(), data.accountKey, data.memberID))
-    {
+        data.time, buy.c_str(), data.accountKey, data.memberID)
+    ) {
         codelog(MARKET__DB_ERROR, "Error in query: %s", res.error.c_str());
         return nullptr;
     }

--- a/src/eve-server/market/MarketProxyService.cpp
+++ b/src/eve-server/market/MarketProxyService.cpp
@@ -117,7 +117,7 @@ PyResult MarketProxyService::CharGetNewTransactions(PyCallArgs &call, PyRep* sel
 {
     Market::TxData data = Market::TxData();
         data.clientID = clientID->IsNone() ? 0 : PyRep::IntegerValueU32(clientID);
-        data.isBuy = sellBuy->IsNone() ? 0 : PyRep::IntegerValueU32(sellBuy);
+        data.isBuy = sellBuy->IsNone() ? -1 : PyRep::IntegerValueU32(sellBuy);
         data.price = minPrice->IsNone() ? 0 : PyRep::IntegerValueU32(minPrice);
         data.quantity = quantity->IsNone() ? 0 : PyRep::IntegerValueU32(quantity);
         data.typeID = typeID->IsNone() ? 0 : PyRep::IntegerValueU32(typeID);


### PR DESCRIPTION
Currently, viewing market transactions in the user's wallet will only show the sold transactions because the `IsNone()` check in `MarketProxyService::CharGetNewTransactions` defaults it to `0`. 

However, a value of `0` is later assumed in `MarketDB::GetTransactions` to be a "sold" filter (and a "buy" filter is a value of `1`).

By updating the defaulted value in `MarketProxyService::CharGetNewTransactions` to `-1` instead of `0`, the wallet transactions view now works.

I also made a few minor legibility improvements in one spot in the code, nothing significant.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the issue with the 'both' filter in the wallet transactions view by changing the default transaction type filter value to -1, ensuring both buy and sell transactions are shown. Enhance code readability with minor formatting improvements.

Bug Fixes:
- Fix the 'both' filter in the wallet transactions view by updating the default value for transaction type filtering from 0 to -1, allowing both buy and sell transactions to be displayed correctly.

Enhancements:
- Improve code legibility in the MarketDB and MarketProxyService by adding spacing and minor formatting adjustments.

<!-- Generated by sourcery-ai[bot]: end summary -->