### PR TITLE
Improvements and fixes for market transactions; code quality improvements

### DIFF
--- a/doc/code_and_design_notes/Alasiya_TODO
+++ b/doc/code_and_design_notes/Alasiya_TODO
@@ -192,8 +192,8 @@ customInfo is actually used in client
     - there are many logConst and event** msgs not implemented/researched (LP, FacWar, StandingTransactions, more)
 
 20:41:06 [Bound] InsuranceBound::InsureShip()
-20:41:06 [AcctTrace] TranserFunds() - from: 90000000, to: 1000132, entry: 19, refID: 0, amount: 0.33, fKey: 1000, tKey: 1000
-20:41:06 [AcctTrace] TranserFunds() - toID: 1000132 is neither player nor player corp.
+20:41:06 [AcctTrace] TransferFunds() - from: 90000000, to: 1000132, entry: 19, refID: 0, amount: 0.33, fKey: 1000, tKey: 1000
+20:41:06 [AcctTrace] TransferFunds() - toID: 1000132 is neither player nor player corp.
 20:41:06 [SvcMsg] New messageID: 1
 20:41:06 [SvcMsg] Delivered message from 1000132 to recipient 90000000
     - ins mail working.  need contractID, expiry date, and few other things...

--- a/src/eve-common/EVE_Defines.h
+++ b/src/eve-common/EVE_Defines.h
@@ -396,7 +396,7 @@
 (itemID == npcTraderJoe)
 
 #define IsTrader(itemID) \
-(((itemID >= minTrader) && (itemID <= maxTrader))
+((itemID >= minTrader) && (itemID <= maxTrader))
 
 
 /*

--- a/src/eve-server/account/AccountService.h
+++ b/src/eve-server/account/AccountService.h
@@ -36,15 +36,31 @@ public:
     AccountService();
 
     // this moves currency, adds journal entries, and sends blink event. handles applicable corp taxes internally.
-    //  will throw if fails
-    static void TranserFunds(uint32 fromID, uint32 toID, double amount, std::string reason = "", \
-                            uint8 entryTypeID = Journal::EntryType::Undefined, uint32 referenceID = 0, \
-                            uint16 fromKey = Account::KeyType::Cash, uint16 toKey = Account::KeyType::Cash, \
-                            Client* pClient=nullptr);
+    // will throw if fails
+    static void TransferFunds(
+        uint32 fromID,
+        uint32 toID,
+        double amount,
+        std::string reason = "",
+        uint8 entryTypeID = Journal::EntryType::Undefined,
+        uint32 referenceID = 0,
+        uint16 fromKey = Account::KeyType::Cash,
+        uint16 toKey = Account::KeyType::Cash,
+        Client* pClient=nullptr
+    );
 
     // this should be the ONLY method to alter corp balances, and ONLY called from TransferFunds()
-    static void HandleCorpTransaction(uint32 corpID, int8 entryTypeID, uint32 fromID, uint32 toID, int8 currency, uint16 accountKey, \
-                                      double amount, std::string description, uint32 referenceID = 0);
+    static void HandleCorpTransaction(
+        uint32 corpID,
+        int8 entryTypeID,
+        uint32 fromID,
+        uint32 toID,
+        int8 currency,
+        uint16 accountKey,
+        double amount,
+        std::string description,
+        uint32 referenceID = 0
+    );
 
 protected:
     AccountDB m_db;

--- a/src/eve-server/agents/AgentBound.cpp
+++ b/src/eve-server/agents/AgentBound.cpp
@@ -270,9 +270,9 @@ PyResult AgentBound::DoAction(PyCallArgs &call, std::optional <PyInt*> actionID)
                 }
                 /** @todo  add fleet sharing  */
                 if (offer.rewardISK)
-                    AccountService::TranserFunds(m_agent->GetID(), pchar->itemID(), offer.rewardISK, "Mission Reward", Journal::EntryType::AgentMissionReward, m_agent->GetID());
+                    AccountService::TransferFunds(m_agent->GetID(), pchar->itemID(), offer.rewardISK, "Mission Reward", Journal::EntryType::AgentMissionReward, m_agent->GetID());
                 if ((offer.bonusTime > 0) and (offer.bonusTime < (offer.dateAccepted - GetFileTimeNow())))
-                    AccountService::TranserFunds(m_agent->GetID(), pchar->itemID(), offer.bonusISK, "Mission Bonus Reward", Journal::EntryType::AgentMissionTimeBonusReward, m_agent->GetID());
+                    AccountService::TransferFunds(m_agent->GetID(), pchar->itemID(), offer.bonusISK, "Mission Bonus Reward", Journal::EntryType::AgentMissionTimeBonusReward, m_agent->GetID());
                 /** @todo  add lp, etc, etc  */
                 if (offer.rewardLP)
                     LPService::AddLP(pchar->itemID(), m_agent->GetCorpID(), offer.rewardLP);

--- a/src/eve-server/character/CharMgrService.cpp
+++ b/src/eve-server/character/CharMgrService.cpp
@@ -239,8 +239,7 @@ PyResult CharMgrService::GetPublicInfo(PyCallArgs &call, PyInt* ownerID) {
     return result;
 }
 
-PyResult CharMgrService::AddToBounty(PyCallArgs& call, PyInt* characterID, PyInt* amount)
-{
+PyResult CharMgrService::AddToBounty(PyCallArgs& call, PyInt* characterID, PyInt* amount) {
     if (call.client->GetCharacterID() == characterID->value()){
         call.client->SendErrorMsg("You cannot put a bounty on yourself.");
         return nullptr;
@@ -249,7 +248,7 @@ PyResult CharMgrService::AddToBounty(PyCallArgs& call, PyInt* characterID, PyInt
     if (amount->value() < call.client->GetBalance()) {
         std::string reason = "Placing Bounty on ";
         reason += m_db.GetCharName(characterID->value());
-        AccountService::TranserFunds(call.client->GetCharacterID(), corpCONCORD, amount->value(), reason, Journal::EntryType::Bounty, characterID->value());
+        AccountService::TransferFunds(call.client->GetCharacterID(), corpCONCORD, amount->value(), reason, Journal::EntryType::Bounty, characterID->value());
         m_db.AddBounty(characterID->value(), call.client->GetCharacterID(), amount->value());
         // new system gives target a mail from concord about placement of bounty and char name placing it.
     } else {

--- a/src/eve-server/character/CharUnboundMgrService.cpp
+++ b/src/eve-server/character/CharUnboundMgrService.cpp
@@ -368,9 +368,8 @@ PyResult CharUnboundMgrService::CreateCharacterWithDoll(PyCallArgs &call, PyRep*
 
     std::string reason = "DESC: Inheritance Payment to ";
     reason += charRef->itemName();
-    AccountService::TranserFunds(corpSCC, charRef->itemID(), sConfig.character.startBalance, reason, Journal::EntryType::Inheritance);
-    AccountService::TranserFunds(corpSCC, charRef->itemID(), sConfig.character.startAurBalance, reason, \
-                            Journal::EntryType::Inheritance, 0, Account::KeyType::AUR, Account::KeyType::AUR);
+    AccountService::TransferFunds(corpSCC, charRef->itemID(), sConfig.character.startBalance, reason, Journal::EntryType::Inheritance);
+    AccountService::TransferFunds(corpSCC, charRef->itemID(), sConfig.character.startAurBalance, reason, Journal::EntryType::Inheritance, 0, Account::KeyType::AUR, Account::KeyType::AUR);
 
     charRef->LogOut();
     sRef->LogOut();

--- a/src/eve-server/character/Character.cpp
+++ b/src/eve-server/character/Character.cpp
@@ -1280,17 +1280,15 @@ void Character::SaveFullCharacter() {
     SaveSkillQueue();
 }
 
-void Character::PayBounty(CharacterRef cRef)
-{
+void Character::PayBounty(CharacterRef cRef) {
     std::string reason = "Bounty for the killing of ";
     reason += cRef->itemName();
-    AccountService::TranserFunds(corpCONCORD, m_itemID, cRef->bounty(), reason, Journal::EntryType::Bounty, cRef->itemID());
+    AccountService::TransferFunds(corpCONCORD, m_itemID, cRef->bounty(), reason, Journal::EntryType::Bounty, cRef->itemID());
     // add data to StatisticMgr
     sStatMgr.Add(Stat::pcBounties, cRef->bounty());
 }
 
-void Character::SetLoginTime()
-{
+void Character::SetLoginTime() {
     m_loginTime = sEntityList.GetStamp();
     m_db.SetLogInTime(m_itemID);
 }

--- a/src/eve-server/contract/ContractProxy.cpp
+++ b/src/eve-server/contract/ContractProxy.cpp
@@ -540,12 +540,12 @@ PyResult ContractProxy::AcceptContract(PyCallArgs &call, PyInt* contractID) {
                 if (iskRequirementMet && rewardRequirementMet && requestedItemsRequirementsMet) {
                     // If we have a reward value - then contract's WTB
                     if (reward > 0) {
-                        AccountService::TranserFunds(issuerID, call.client->GetCharacterID(), reward, "Payment for accepted contract", Journal::EntryType::ContractReward, contractID->value());
+                        AccountService::TransferFunds(issuerID, call.client->GetCharacterID(), reward, "Payment for accepted contract", Journal::EntryType::ContractReward, contractID->value());
                     }
 
                     // If we have price value - then contract's WTS
                     if (price > 0) {
-                        AccountService::TranserFunds(call.client->GetCharacterID(), issuerID, price, "Payment for accepted contract", Journal::EntryType::ContractPrice, contractID->value());
+                        AccountService::TransferFunds(call.client->GetCharacterID(), issuerID, price, "Payment for accepted contract", Journal::EntryType::ContractPrice, contractID->value());
                     }
 
                     // Then, we go for requested items
@@ -762,7 +762,7 @@ PyResult ContractProxy::CompleteContract(PyCallArgs &call, PyInt* contractID, Py
             if (collateral > 0) {
                 // Since we've taken the collateral prior to it and left it "hanging in the air" we put it back into acceptor's wallet and then issue a transfer
                 call.client->AddBalance(collateral);
-                AccountService::TranserFunds(call.client->GetCharacterID(), issuerID, collateral, "Collateral payment for failed contract", Journal::EntryType::ContractCollateral, contractID->value());
+                AccountService::TransferFunds(call.client->GetCharacterID(), issuerID, collateral, "Collateral payment for failed contract", Journal::EntryType::ContractCollateral, contractID->value());
             }
             // Then, we update the contract as Афшдув.
             DBerror err;

--- a/src/eve-server/corporation/CorpRegistryBound.cpp
+++ b/src/eve-server/corporation/CorpRegistryBound.cpp
@@ -580,14 +580,16 @@ PyResult CorpRegistryBound::AddCorporation(PyCallArgs &call,
     reason += " (";
     reason += args.corpTicker;
     reason += ")";
-    AccountService::TranserFunds(
-                                pClient->GetCharacterID(),
-                                m_db.GetStationOwner(pClient->GetStationID()),  // station owner files paperwork, this is fee for that
-                                corp_cost,
-                                reason.c_str(),
-                                Journal::EntryType::CorporationRegistrationFee,
-                                pClient->GetStationID(),
-                                Account::KeyType::Cash);
+
+    AccountService::TransferFunds(
+        pClient->GetCharacterID(),
+        m_db.GetStationOwner(pClient->GetStationID()),  // station owner files paperwork, this is fee for that
+        corp_cost,
+        reason.c_str(),
+        Journal::EntryType::CorporationRegistrationFee,
+        pClient->GetStationID(),
+        Account::KeyType::Cash
+    );
 
     // add corp event for creating new corp
     m_db.AddItemEvent(corpID, pClient->GetCharacterID(), Corp::EventType::CreatedCorporation);
@@ -782,14 +784,16 @@ PyResult CorpRegistryBound::UpdateLogo(PyCallArgs &call,
     }
 
     std::string reason = "Change Corporation Logo.";
+
     // move cash and record the transaction.
-    AccountService::TranserFunds(
+    AccountService::TransferFunds(
         call.client->GetCharacterID(),
-                                 m_db.GetStationOwner(call.client->GetStationID()),
-                                 logo_change,
-                                 reason,
-                                 Journal::EntryType::CorporationLogoChangeCost,
-                                 Account::KeyType::Cash);   // main wallet
+        m_db.GetStationOwner(call.client->GetStationID()),
+        logo_change,
+        reason,
+        Journal::EntryType::CorporationLogoChangeCost,
+        Account::KeyType::Cash
+    ); // main wallet
 
     // Send notification to those in the station
     /** @todo update this to use CorpNotify() */
@@ -886,7 +890,7 @@ PyResult CorpRegistryBound::CreateRecruitmentAd(PyCallArgs &call, PyInt* days, P
         case 28:   amount = 7500000;  break;
     }
 
-    AccountService::TranserFunds(m_corpID, call.client->GetCorpHQ(), amount, "Initial Advert Time for Corp Recruit Advert", Journal::EntryType::CorporationAdvertisementFee, call.client->GetCharacterID());
+    AccountService::TransferFunds(m_corpID, call.client->GetCorpHQ(), amount, "Initial Advert Time for Corp Recruit Advert", Journal::EntryType::CorporationAdvertisementFee, call.client->GetCharacterID());
 
     int32 adID = m_db.CreateAdvert(call.client, m_corpID, typeMask->value(), days->value(), m_db.GetCorpMemberCount(m_corpID), description->content(), channelID->value(), title->content());
 
@@ -936,7 +940,7 @@ PyResult CorpRegistryBound::UpdateRecruitmentAd(PyCallArgs &call, PyInt* adID, P
             case 14:   amount = 3500000;  break;
         }
 
-        AccountService::TranserFunds(m_corpID, call.client->GetCorpHQ(), amount, "Added Advert Time to Corp Recruit Advert", Journal::EntryType::CorporationAdvertisementFee);
+        AccountService::TransferFunds(m_corpID, call.client->GetCorpHQ(), amount, "Added Advert Time to Corp Recruit Advert", Journal::EntryType::CorporationAdvertisementFee);
 
         // do some funky shit to determine days left for advert then add additional time if requested
         int64 time = m_db.GetAdvertTime(adID->value(), m_corpID);
@@ -1288,14 +1292,17 @@ PyResult CorpRegistryBound::PayoutDividend(PyCallArgs &call, PyBool* paySharehol
 
     // get total amount and divide by # of ids to pay
     float amount = payoutAmount->value() / toIDs.size();
-    if (amount < 0.01)
+    if (amount < 0.01) {
         return nullptr;  //make error here?
+    }
 
-        // pay each id and record xfer
-        std::string reason = "Dividend Payment from ";
+    // pay each id and record xfer
+    std::string reason = "Dividend Payment from ";
     reason += ""; //corp name here
-    for (auto cur : toIDs)
-        AccountService::TranserFunds(m_corpID, cur, amount, reason.c_str(), Journal::EntryType::CorporationDividendPayment, call.client->GetCharacterID());
+
+    for (auto cur : toIDs) {
+        AccountService::TransferFunds(m_corpID, cur, amount, reason.c_str(), Journal::EntryType::CorporationDividendPayment, call.client->GetCharacterID());
+    }
 
     return nullptr;
 }
@@ -2305,7 +2312,7 @@ PyResult CorpRegistryBound::CreateAlliance(PyCallArgs &call, PyRep* allianceName
 
     AllianceDB a_db;
     Client* pClient(call.client);
-    
+
     std::string allianceNameStr = PyRep::StringContent(allianceName);
     std::string shortNameStr = PyRep::StringContent(shortName);
     std::string descriptionStr = PyRep::StringContent(description);
@@ -2345,14 +2352,16 @@ PyResult CorpRegistryBound::CreateAlliance(PyCallArgs &call, PyRep* allianceName
     reason += " (";
     reason += shortNameStr;
     reason += ")";
-    AccountService::TranserFunds(
-                                pClient->GetCharacterID(),
-                                m_db.GetStationOwner(pClient->GetStationID()),  // station owner files paperwork, this is fee for that
-                                ally_cost,
-                                reason.c_str(),
-                                Journal::EntryType::AllianceRegistrationFee,
-                                pClient->GetStationID(),
-                                Account::KeyType::Cash);
+
+    AccountService::TransferFunds(
+        pClient->GetCharacterID(),
+        m_db.GetStationOwner(pClient->GetStationID()),  // station owner files paperwork, this is fee for that
+        ally_cost,
+        reason.c_str(),
+        Journal::EntryType::AllianceRegistrationFee,
+        pClient->GetStationID(),
+        Account::KeyType::Cash
+    );
 
     //creating an alliance will affect eveStaticOwners, so we gotta invalidate the cache...
     //  call to db.AddCorporation() will update eveStaticOwners with new corp

--- a/src/eve-server/corporation/CorpStationMgr.cpp
+++ b/src/eve-server/corporation/CorpStationMgr.cpp
@@ -225,14 +225,16 @@ PyResult CorpStationMgrIMBound::SetCloneTypeID(PyCallArgs &call, PyInt* cloneTyp
     reason += call.client->GetSystemName();
     reason += " at ";
     reason += stDataMgr.GetStationName(call.client->GetStationID());
-    AccountService::TranserFunds(
-                    call.client->GetCharacterID(),
-                    call.client->GetStationID(),
-                    cost,
-                    reason.c_str(),
-                    Journal::EntryType::CloneActivation,
-                    call.client->GetStationID(),
-                    Account::KeyType::Cash);
+
+    AccountService::TransferFunds(
+        call.client->GetCharacterID(),
+        call.client->GetStationID(),
+        cost,
+        reason.c_str(),
+        Journal::EntryType::CloneActivation,
+        call.client->GetStationID(),
+        Account::KeyType::Cash
+    );
 
     //update type of clone
     CharacterDB c_db;
@@ -260,7 +262,9 @@ PyResult CorpStationMgrIMBound::RentOffice(PyCallArgs &call, PyInt* amount) {
     reason += pStationItem->itemName();
     reason += " by ";
     reason += pClient->GetCharName();
-    AccountService::TranserFunds(pClient->GetCorporationID(), pStationItem->GetOwnerID(), amount->value(), reason.c_str(), Journal::EntryType::OfficeRentalFee);
+
+    AccountService::TransferFunds(pClient->GetCorporationID(), pStationItem->GetOwnerID(), amount->value(), reason.c_str(), Journal::EntryType::OfficeRentalFee);
+
 /** @note  why is this disabled?
     int64 balance = AccountDB::GetCorpBalance(pClient->GetCorporationID(), Account::KeyType::Cash);
     if (balance < arg.arg) {

--- a/src/eve-server/corporation/CorporationService.cpp
+++ b/src/eve-server/corporation/CorporationService.cpp
@@ -138,8 +138,7 @@ PyResult CorporationService::GetRecruitmentAdsForCorporation(PyCallArgs& call)
  * @note   these below are partially coded
  */
 
-PyResult CorporationService::CreateMedal(PyCallArgs &call, PyWString* name, PyWString* description, PyList* medalData)
-{
+PyResult CorporationService::CreateMedal(PyCallArgs &call, PyWString* name, PyWString* description, PyList* medalData) {
     // destroy = sm.StartService('medals').CreateMedal(mName, mDesc, cMedalData)
     //  destroy = true will close window
 
@@ -149,14 +148,16 @@ PyResult CorporationService::CreateMedal(PyCallArgs &call, PyWString* name, PyWS
     reason += call.client->GetName();
     reason += " in ";   // just extra shit.  this will show in tooltip.  ;)
     reason += stDataMgr.GetStationName(call.client->GetStationID());
-    AccountService::TranserFunds(
-                                 call.client->GetCorporationID(),
-                                 call.client->GetStationID(),
-                                 sConfig.rates.medalCreateCost,
-                                 reason.c_str(),
-                                 Journal::EntryType::MedalCreation,
-                                 call.client->GetStationID(),
-                                 Account::KeyType::Cash);
+    AccountService::TransferFunds(
+        call.client->GetCorporationID(),
+        call.client->GetStationID(),
+        sConfig.rates.medalCreateCost,
+        reason.c_str(),
+        Journal::EntryType::MedalCreation,
+        call.client->GetStationID(),
+        Account::KeyType::Cash
+    );
+
     if (name->size() > 30)
         throw UserError ("MedalNameTooLong");
     if (description->size() < 3)
@@ -254,8 +255,7 @@ PyResult CorporationService::GetRecipientsOfMedal(PyCallArgs &call, PyInt* medal
     return m_db.GetRecipientsOfMedal(medalID->value());
 }
 
-PyResult CorporationService::GiveMedalToCharacters(PyCallArgs &call, PyInt* medalID, PyList* recipientIDs, PyWString* reason)
-{
+PyResult CorporationService::GiveMedalToCharacters(PyCallArgs &call, PyInt* medalID, PyList* recipientIDs, PyWString* reason) {
     //  sm.RemoteSvc('corporationSvc').GiveMedalToCharacters(medalID, recipientID, reason)
     /*
      * 13:24:32 [CorpCallDump]   Call Arguments:
@@ -279,12 +279,13 @@ PyResult CorporationService::GiveMedalToCharacters(PyCallArgs &call, PyInt* meda
     //take the money, send wallet blink event record the transaction in corp journal.
     std::string finalReason = "DESC: Awarding Medal by ";
     finalReason += call.client->GetName();
-    AccountService::TranserFunds(
-                                 call.client->GetCorporationID(),
-                                 call.client->GetStationID(),
-                                 cost,
-                                 finalReason,
-                                 Journal::EntryType::MedalIssuing);
+    AccountService::TransferFunds(
+        call.client->GetCorporationID(),
+        call.client->GetStationID(),
+        cost,
+        finalReason,
+        Journal::EntryType::MedalIssuing
+    );
 
     m_db.GiveMedalToCharacters(call.client->GetCharacterID(), call.client->GetCorporationID(), medalID->value(), charVec, reason->content());
 

--- a/src/eve-server/manufacturing/RamProxyService.cpp
+++ b/src/eve-server/manufacturing/RamProxyService.cpp
@@ -217,7 +217,6 @@ PyResult RamProxyService::InstallJob(PyCallArgs &call, PyRep* locationData, PyRe
     sRamMthd.LinePermissionCheck(call.client, args);
     sRamMthd.ItemOwnerCheck(call.client, args, bpRef);
 
-
     // this is a bit funky, but works quite well....
     // decode path to BP and BOM location
     // i am populating this for corp and personal to have common call to mat'l checks that follow
@@ -326,6 +325,7 @@ PyResult RamProxyService::InstallJob(PyCallArgs &call, PyRep* locationData, PyRe
     std::string reason = "DESC: Installing ";
     reason += sRamMthd.GetActivityName(args.activityID);
     reason += " job in ";
+
     if (sDataMgr.IsStation(locationID)) {
         reason += stDataMgr.GetStationName(locationID);
     } else {    // test for POS after that system is more complete...
@@ -336,13 +336,16 @@ PyResult RamProxyService::InstallJob(PyCallArgs &call, PyRep* locationData, PyRe
         reason += " by ";
         reason += call.client->GetName();
     }
-    AccountService::TranserFunds(call.client->GetCharacterID(),
-                                 stDataMgr.GetOwnerID(locationID),
-                                 cost,
-                                 reason.c_str(),
-                                 Journal::EntryType::FactorySlotRentalFee,
-                                 locationID,    // shows rental location (stationID)
-                                 Account::KeyType::Cash);
+
+    AccountService::TransferFunds(
+        call.client->GetCharacterID(),
+        stDataMgr.GetOwnerID(locationID),
+        cost,
+        reason.c_str(),
+        Journal::EntryType::FactorySlotRentalFee,
+        locationID,    // shows rental location (stationID)
+        Account::KeyType::Cash
+    );
 
     int64 beginTime(GetFileTimeNow());
     if (beginTime < rsp.maxJobStartTime)
@@ -545,6 +548,7 @@ PyResult RamProxyService::InstallJob(PyCallArgs &call, PyRep* locationData, PyRe
 
     // increment statistic counter
     sStatMgr.Increment(Stat::ramJobs);
+
     return nullptr;
 }
 

--- a/src/eve-server/market/MarketMgr.h
+++ b/src/eve-server/market/MarketMgr.h
@@ -39,8 +39,12 @@ public:
 
     void UpdatePriceHistory();
 
-    // fulfill market order placed by buyer to buy items (usually at reduced prices).
-    // updates qty in args based on order request.  returns false if/when entire quantity is filled.
+    // fulfill market order placed by buyer to buy items (usually at reduced
+    // prices).
+    //
+    // Updates qty in args based on order request.
+    //
+    // Returns true if the order is complete; false otherwise.
     bool ExecuteBuyOrder(Client* seller, uint32 orderID, InventoryItemRef iRef, uint32 quantity, bool useCorp, uint32 typeID, uint32 stationID, double price, uint16 accountKey = Account::KeyType::Cash);
     // market order placed by seller to sell items (usually at higher prices)
     void ExecuteSellOrder(Client *buyer, uint32 orderID, uint32 quantity, float price, uint32 stationID, uint32 typeID, bool useCorp);

--- a/src/eve-server/market/MarketProxyService.cpp
+++ b/src/eve-server/market/MarketProxyService.cpp
@@ -467,7 +467,7 @@ PyResult MarketProxyService::PlaceCharOrder(PyCallArgs &call, PyInt* stationID, 
             // set an upper bound (this used to be a while loop that spun
             // forever in some cases)
             for (int i = 0; i < 1000; i++) {
-                _log(MARKET__DUMP, "Mkt::PlaceCharOrder(): issue 16 - finding buy order: %i, %i, %i, %.2f", typeID->value(), stationID->value(), quantity->value(), price->value());
+                _log(MARKET__DUMP, "Mkt::PlaceCharOrder(): finding buy order: %i, %i, %i, %.2f", typeID->value(), stationID->value(), quantity->value(), price->value());
 
                 orderID = MarketDB::FindBuyOrder(typeID->value(), stationID->value(), quantity->value(), price->value());
 
@@ -497,12 +497,13 @@ PyResult MarketProxyService::PlaceCharOrder(PyCallArgs &call, PyInt* stationID, 
                     continue;
                 }
 
-                _log(MARKET__DUMP, "Mkt::PlaceCharOrder(): issue 16 - order completed");
+                _log(MARKET__DUMP, "Mkt::PlaceCharOrder(): order resolved");
+
                 break;
             }
 
             if (!completedOrder) {
-                _log(MARKET__ERROR, "PlaceCharOrder - failed to find a matching market order within 1000 attempts. 1");
+                _log(MARKET__ERROR, "PlaceCharOrder - failed to find a matching market order within 1000 attempts.");
 
                 call.client->SendErrorMsg("Failed to find a suitable market order in a reasonable amount of time.");
 

--- a/src/eve-server/market/MarketProxyService.cpp
+++ b/src/eve-server/market/MarketProxyService.cpp
@@ -37,7 +37,6 @@
 #include "system/SystemManager.h"
 #include "standing/StandingDB.h"
 
-
 /*
  * MARKET__ERROR
  * MARKET__WARNING
@@ -113,16 +112,17 @@ PyResult MarketProxyService::GetNewPriceHistory(PyCallArgs& call, PyInt* typeID)
     return sMktMgr.GetNewPriceHistory(call.client->GetRegionID(), typeID->value());
 }
 
-PyResult MarketProxyService::CharGetNewTransactions(PyCallArgs &call, PyRep* sellBuy, PyRep* typeID, PyRep* clientID, PyRep* quantity, PyRep* fromDate, PyRep* maxPrice, PyRep* minPrice)
-{
+PyResult MarketProxyService::CharGetNewTransactions(PyCallArgs &call, PyRep* sellBuy, PyRep* typeID, PyRep* clientID, PyRep* quantity, PyRep* fromDate, PyRep* maxPrice, PyRep* minPrice) {
     Market::TxData data = Market::TxData();
-        data.clientID = clientID->IsNone() ? 0 : PyRep::IntegerValueU32(clientID);
-        data.isBuy = sellBuy->IsNone() ? -1 : PyRep::IntegerValueU32(sellBuy);
-        data.price = minPrice->IsNone() ? 0 : PyRep::IntegerValueU32(minPrice);
-        data.quantity = quantity->IsNone() ? 0 : PyRep::IntegerValueU32(quantity);
-        data.typeID = typeID->IsNone() ? 0 : PyRep::IntegerValueU32(typeID);
-        data.time = fromDate->IsNone() ? 0 : PyRep::IntegerValue(fromDate);
-        data.accountKey = Account::KeyType::Cash;
+
+    data.clientID = clientID->IsNone() ? 0 : PyRep::IntegerValueU32(clientID);
+    data.isBuy = sellBuy->IsNone() ? -1 : PyRep::IntegerValueU32(sellBuy);
+    data.price = minPrice->IsNone() ? 0 : PyRep::IntegerValueU32(minPrice);
+    data.quantity = quantity->IsNone() ? 0 : PyRep::IntegerValueU32(quantity);
+    data.typeID = typeID->IsNone() ? 0 : PyRep::IntegerValueU32(typeID);
+    data.time = fromDate->IsNone() ? 0 : PyRep::IntegerValue(fromDate);
+    data.accountKey = Account::KeyType::Cash;
+
     return MarketDB::GetTransactions(call.client->GetCharacterID(), data);
 }
 
@@ -177,22 +177,23 @@ PyResult MarketProxyService::PlaceCharOrder(PyCallArgs &call, PyInt* stationID, 
     //   itemID = None, int(minVolume = 1), int(duration = 14), useCorp = False, located = None)
     // located = [officeFolderID, officeID] or None
 
-  /*
-21:47:34 [MktDump] Mkt::PlaceCharOrder()
-21:47:34 [MktDump]     Call_PlaceCharOrder
-21:47:34 [MktDump]     stationID=60014137
-21:47:34 [MktDump]     typeID=20327
-21:47:34 [MktDump]     price=100.0000000000000
-21:47:34 [MktDump]     quantity=1
-21:47:34 [MktDump]     bid=1
-21:47:34 [MktDump]     orderRange=4294967295
-21:47:34 [MktDump]     itemID=0
-21:47:34 [MktDump]     minVolume=1
-21:47:34 [MktDump]     duration=0
-21:47:34 [MktDump]     useCorp=0
-21:47:34 [MktDump]     located:
-21:47:34 [MktDump]               None
-*/
+    /*
+    21:47:34 [MktDump] Mkt::PlaceCharOrder()
+    21:47:34 [MktDump]     Call_PlaceCharOrder
+    21:47:34 [MktDump]     stationID=60014137
+    21:47:34 [MktDump]     typeID=20327
+    21:47:34 [MktDump]     price=100.0000000000000
+    21:47:34 [MktDump]     quantity=1
+    21:47:34 [MktDump]     bid=1
+    21:47:34 [MktDump]     orderRange=4294967295
+    21:47:34 [MktDump]     itemID=0
+    21:47:34 [MktDump]     minVolume=1
+    21:47:34 [MktDump]     duration=0
+    21:47:34 [MktDump]     useCorp=0
+    21:47:34 [MktDump]     located:
+    21:47:34 [MktDump]               None
+    */
+
     // not sent from call, but used in transactions
     uint16 accountKey(Account::KeyType::Cash);
 
@@ -215,17 +216,18 @@ PyResult MarketProxyService::PlaceCharOrder(PyCallArgs &call, PyInt* stationID, 
      * corp checks coded for ram/reproc.  use as template
      */
 
-    if (bid->value() and (itemID.has_value () == false || itemID.value()->value() == 0)) {  //buy
+    if (bid->value() and (itemID.has_value () == false || itemID.value()->value() == 0)) {  // buy
         // check for corp usage and get standings with station owners
         float fStanding(0), cStanding(0);
         if (useCorp->value()) {
-            // it is.  perform checks and set needed variables for corp use
+            // it is. perform checks and set needed variables for corp use
             if (!IsPlayerCorp(call.client->GetCorporationID())) {
                 // cant buy items for npc corp...
                 call.client->SendErrorMsg("You cannot buy items for an NPC corp.");
                 return nullptr;
             }
-            // this is a corp transaction.  verify char can buy shit for corp...
+
+            // this is a corp transaction. verify char can buy things for corp...
             // some corp error msgs in inventory.h, corp.h and market.h
             //   will need corp methods to determine member access rights for item location and roles....
             //   these may be written already.  will have to check
@@ -233,23 +235,52 @@ PyResult MarketProxyService::PlaceCharOrder(PyCallArgs &call, PyInt* stationID, 
             accountKey = call.client->GetCorpAccountKey();
         }
 
-        //is this standing order or immediate?
+        // is this standing order or immediate?
         if (duration->value() == 0) {
-            // immediate.  look for open sell order that matches all reqs (price, qty, distance, etc)
-            // check distance shit, set order range and make station list.  this shit will be nuts.
-            uint32 orderID(MarketDB::FindSellOrder(typeID->value(), stationID->value(), quantity->value(), price->value()));
+            // immediate. look for open sell order that matches all reqs (price, qty, distance, etc)
+            // check distance, set order range and make station list.
+            uint32 orderID(MarketDB::FindSellOrder(
+                typeID->value(),
+                stationID->value(),
+                quantity->value(),
+                price->value()
+            ));
+
             if (orderID) {
                 // found one.
-                _log(MARKET__TRACE, "PlaceCharOrder - Found sell order #%u in %s for %s. (type %i, price %.2f, qty %i, range %i)", \
-                        orderID, stDataMgr.GetStationName(stationID->value()).c_str(), call.client->GetName(), typeID->value(), price->value(), quantity->value(), orderRange->value());
+                _log(MARKET__TRACE,
+                    "PlaceCharOrder - Found sell order #%u in %s for %s. (type %i, price %.2f, qty %i, range %i)",
+                    orderID,
+                    stDataMgr.GetStationName(stationID->value()).c_str(),
+                    call.client->GetName(),
+                    typeID->value(),
+                    price->value(),
+                    quantity->value(),
+                    orderRange->value()
+                );
 
-                sMktMgr.ExecuteSellOrder(call.client, orderID, quantity->value(), price->value(), stationID->value(), typeID->value(), useCorp->value());
+                sMktMgr.ExecuteSellOrder(
+                    call.client,
+                    orderID,
+                    quantity->value(),
+                    price->value(),
+                    stationID->value(),
+                    typeID->value(),
+                    useCorp->value()
+                );
+
                 return nullptr;
             }
 
-            _log(MARKET__TRACE, "PlaceCharOrder - Failed to satisfy buy order for %i of type %i at %.2f ISK.", \
-                    quantity->value(), typeID->value(), price->value());
+            _log(MARKET__TRACE,
+                "PlaceCharOrder - Failed to satisfy buy order for %i of type %i at %.2f ISK.",
+                quantity->value(),
+                typeID->value(),
+                price->value()
+            );
+
             call.client->SendErrorMsg("No sell order found.");  // find/implement type name here
+
             return nullptr;
         }
 
@@ -303,24 +334,22 @@ PyResult MarketProxyService::PlaceCharOrder(PyCallArgs &call, PyInt* stationID, 
 
         float fee = EvEMath::Market::BrokerFee(lvl, factionStanding, ownerStanding, money);
         _log(MARKET__DEBUG, "PlaceCharOrder(buy) - %s: Escrow: %.2f, Fee: %.2f", useCorp->value() ?"Corp":"Player", money, fee);
+
         // take monies and record actions
         if (useCorp->value()) {
-            AccountService::TranserFunds(call.client->GetCorporationID(), stDataMgr.GetOwnerID(stationID->value()), fee, \
-                reason.c_str(), Journal::EntryType::Brokerfee, orderID, accountKey, Account::KeyType::Cash, call.client);
-            AccountService::TranserFunds(call.client->GetCorporationID(), stDataMgr.GetOwnerID(stationID->value()), money, \
-                reason.c_str(), Journal::EntryType::MarketEscrow, orderID, accountKey, Account::KeyType::Escrow, call.client);
+            AccountService::TransferFunds(call.client->GetCorporationID(), stDataMgr.GetOwnerID(stationID->value()), fee, reason.c_str(), Journal::EntryType::Brokerfee, orderID, accountKey, Account::KeyType::Cash, call.client);
+            AccountService::TransferFunds(call.client->GetCorporationID(), stDataMgr.GetOwnerID(stationID->value()), money, reason.c_str(), Journal::EntryType::MarketEscrow, orderID, accountKey, Account::KeyType::Escrow, call.client);
         } else {
-            AccountService::TranserFunds(call.client->GetCharacterID(), stDataMgr.GetOwnerID(stationID->value()), fee, \
-                reason.c_str(), Journal::EntryType::Brokerfee, orderID, accountKey);
-            AccountService::TranserFunds(call.client->GetCharacterID(), stDataMgr.GetOwnerID(stationID->value()), money, \
-                reason.c_str(), Journal::EntryType::MarketEscrow, orderID, accountKey, Account::KeyType::Escrow);
+            AccountService::TransferFunds(call.client->GetCharacterID(), stDataMgr.GetOwnerID(stationID->value()), fee, reason.c_str(), Journal::EntryType::Brokerfee, orderID, accountKey);
+            AccountService::TransferFunds(call.client->GetCharacterID(), stDataMgr.GetOwnerID(stationID->value()), money, reason.c_str(), Journal::EntryType::MarketEscrow, orderID, accountKey, Account::KeyType::Escrow);
         }
 
         //send notification of new order...
         sMktMgr.InvalidateOrdersCache(call.client->GetRegionID(), typeID->value());
         sMktMgr.SendOnOwnOrderChanged(call.client, orderID, Market::Action::Add, useCorp->value());
     } else {
-        //sell order
+        _log(MARKET__DUMP, "Mkt::PlaceCharOrder(): appears to be a sell order");
+        // sell order
         /*if (!args.located->IsNone()) {
             //  corp item in corp hangar
             // located = [officeFolderID, officeID] or None
@@ -331,30 +360,42 @@ PyResult MarketProxyService::PlaceCharOrder(PyCallArgs &call, PyInt* stationID, 
         InventoryItemRef iRef = sItemFactory.GetItemRef(itemID.value ()->value());
         if (iRef.get() == nullptr) {
             _log(ITEM__ERROR, "PlaceCharOrder - Failed to find item %i for sell order.", itemID.value ()->value());
+
             call.client->SendErrorMsg("Unable to find item to sell.");
+
             return nullptr;
         }
 
         if (iRef->typeID() != typeID->value()) {
             _log(MARKET__MESSAGE, "PlaceCharOrder - Denying Sell of typeID %u using typeID %i.", iRef->typeID(), typeID->value());
+
             call.client->SendErrorMsg("Invalid sell order item type.");
+
             return nullptr;
         }
 
         if (iRef->quantity() < quantity->value()) {
             // trying to sell more than they have
-            _log(MARKET__MESSAGE, "PlaceCharOrder - Denying inflated qty for %s", call.client->GetName());
-            call.client->SendErrorMsg("You cannot sell %i %s when you only have %i.  If applicable, merge stacks and try again.", \
-                quantity->value(), iRef->name(), iRef->quantity());
+            _log(MARKET__MESSAGE,
+                "PlaceCharOrder - Denying inflated qty for %s",
+                call.client->GetName());
+                call.client->SendErrorMsg("You cannot sell %i %s when you only have %i.  If applicable, merge stacks and try again.",
+                quantity->value(),
+                iRef->name(),
+                iRef->quantity()
+            );
+
             return nullptr;
         }
-        //verify right to sell this thing..
+
+        // verify right to sell this thing..
         if (useCorp->value()) {
             if (!IsPlayerCorp(call.client->GetCorporationID())) {
                 // cant sell npc corp items...
                 call.client->SendErrorMsg("You cannot sell items for an NPC corp.");
                 return nullptr;
             }
+
             // this is a corp transaction.  verify char can sell corp shit...
             // some corp error msgs in inventory.h, corp.h and market.h
             //   will need corp methods to determine member access rights for item location and roles....
@@ -362,19 +403,28 @@ PyResult MarketProxyService::PlaceCharOrder(PyCallArgs &call, PyInt* stationID, 
             accountKey = call.client->GetCorpAccountKey();
         } else {
             if ( iRef->ownerID() != call.client->GetCharacterID()) {
-                _log(MARKET__WARNING, "%s(%u) Tried to sell %i %s owned by %u in %s.", \
-                        call.client->GetName(), call.client->GetCharID(), iRef->quantity(), \
-                        iRef->name(), iRef->ownerID(), stDataMgr.GetStationName(stationID->value()).c_str());
+                _log(MARKET__WARNING,
+                    "%s(%u) Tried to sell %i %s owned by %u in %s.",
+                    call.client->GetName(),
+                    call.client->GetCharID(),
+                    iRef->quantity(),
+                    iRef->name(),
+                    iRef->ownerID(),
+                    stDataMgr.GetStationName(stationID->value()).c_str()
+                );
+
                 call.client->SendErrorMsg("You cannot sell items you do not own.");
+
                 return nullptr;
             }
         }
 
-        //verify valid location
-        if (( iRef->locationID() != stationID->value())   //item in station hanger
-        and !(call.client->GetShip()->GetMyInventory()->ContainsItem( iRef->itemID() )  //item is in our ship
-        and call.client->GetStationID() == stationID->value()))   //and our ship is in the station
-        {
+        // verify valid location
+        bool itemInStationHangar(iRef->locationID() != stationID->value());
+        bool itemInShip(!(call.client->GetShip()->GetMyInventory()->ContainsItem(iRef->itemID())));
+        bool shipInStation(call.client->GetStationID() == stationID->value());
+
+        if (itemInStationHangar && itemInShip && shipInStation) {
             std::string itemLoc;
             if (sDataMgr.IsStation(iRef->locationID())) {
                 itemLoc = stDataMgr.GetStationName(iRef->locationID());
@@ -383,56 +433,86 @@ PyResult MarketProxyService::PlaceCharOrder(PyCallArgs &call, PyInt* stationID, 
             } else {
                 itemLoc = "an Invalid Location";
             }
-            _log(MARKET__ERROR, "%s Trying to sell %s(%u) in %s through %s while in %s", \
-                    call.client->GetName(), iRef->name(), iRef->itemID(), itemLoc.c_str(), \
-                    stDataMgr.GetStationName(stationID->value()).c_str(), stDataMgr.GetStationName(call.client->GetStationID()).c_str());
-            call.client->SendErrorMsg("You cannot sell %s from %s while you are in %s.  Locations mismatch", \
-                    iRef->name(), stDataMgr.GetStationName(stationID->value()).c_str(), stDataMgr.GetStationName(call.client->GetStationID()).c_str());
+
+            _log(MARKET__ERROR,
+                "%s Trying to sell %s(%u) in %s through %s while in %s",
+                call.client->GetName(),
+                iRef->name(),
+                iRef->itemID(),
+                itemLoc.c_str(),
+                stDataMgr.GetStationName(stationID->value()).c_str(),
+                stDataMgr.GetStationName(call.client->GetStationID()).c_str()
+            );
+
+            call.client->SendErrorMsg(
+                "You cannot sell %s from %s while you are in %s.  Locations mismatch",
+                iRef->name(),
+                stDataMgr.GetStationName(stationID->value()).c_str(),
+                stDataMgr.GetStationName(call.client->GetStationID()).c_str()
+            );
+
             return nullptr;
         }
 
-        //TODO: verify orderRange against their skills.   client may do this...verify
+        //TODO: verify orderRange against their skills. client may do this...verify
 
         // they are allowed to sell this thing...
 
-        //is this standing order or immediate?
+        // is this standing order or immediate?
         if (duration->value() == 0) {
-            // immediate - loop to search and fill buy orders at or above asking price until qty depleted or no orders found
-            bool search(true);
+            bool completedOrder(false);
+
             uint32 orderID(0), origQty(quantity->value());
-            while (quantity->value() and search) {
+
+            // set an upper bound (this used to be a while loop that spun
+            // forever in some cases)
+            for (int i = 0; i < 1000; i++) {
+                _log(MARKET__DUMP, "Mkt::PlaceCharOrder(): issue 16 - finding buy order: %i, %i, %i, %.2f", typeID->value(), stationID->value(), quantity->value(), price->value());
+
                 orderID = MarketDB::FindBuyOrder(typeID->value(), stationID->value(), quantity->value(), price->value());
-                if (orderID) {
-                    _log(MARKET__TRACE, "PlaceCharOrder - Found buy order #%u in %s for %s.", \
-                            orderID, stDataMgr.GetStationName(stationID->value()).c_str(), call.client->GetName());
-                    search = sMktMgr.ExecuteBuyOrder(call.client, orderID, iRef, quantity->value(), useCorp->value(), typeID->value(), stationID->value(), price->value());
+
+                if (!orderID) {
+                    continue;
                 }
+
+                _log(MARKET__TRACE,
+                    "PlaceCharOrder - Found buy order #%u in %s for %s.",
+                    orderID,
+                    stDataMgr.GetStationName(stationID->value()).c_str(),
+                    call.client->GetName()
+                );
+
+                completedOrder = sMktMgr.ExecuteBuyOrder(
+                    call.client,
+                    orderID,
+                    iRef,
+                    quantity->value(),
+                    useCorp->value(),
+                    typeID->value(),
+                    stationID->value(),
+                    price->value()
+                );
+
+                if (!completedOrder) {
+                    continue;
+                }
+
+                _log(MARKET__DUMP, "Mkt::PlaceCharOrder(): issue 16 - order completed");
+                break;
             }
 
-            // test for qty change for correct msg.
-            if (quantity->value() == 0) {
-                // completely fulfilled.  msgs sent from ExecuteBuyOrder()
-                return nullptr;
-            } else if (quantity->value() == origQty) {
-                //unable to find any order for this item using client parameters
-                // find/implement type name here?
-                _log(MARKET__TRACE, "PlaceCharOrder - Failed to find any buy order for type %i at %.2f ISK.", \
-                        typeID->value(), price->value());
-                call.client->SendErrorMsg("No buy order found.");
-                return nullptr;
-            } else {
-                // partially filled
-                _log(MARKET__TRACE, "PlaceCharOrder - Failed to find buy orders for remaining %i of type %i at %.2f ISK.", \
-                        quantity->value(), typeID->value(), price->value());
-                call.client->SendErrorMsg("There were only buyers for %u of the %i items you wanted to sell.", quantity->value(), origQty);
+            if (!completedOrder) {
+                _log(MARKET__ERROR, "PlaceCharOrder - failed to find a matching market order within 1000 attempts. 1");
+
+                call.client->SendErrorMsg("Failed to find a suitable market order in a reasonable amount of time.");
+
                 return nullptr;
             }
 
-            _log(MARKET__ERROR, "PlaceCharOrder - immediate order qty hit end of conditional.");\
             return nullptr;
         }
 
-        // they will be placing a sell order.
+        // they will be placing a sell order:
 
         // set save data
         Market::SaveData data = Market::SaveData();
@@ -460,16 +540,18 @@ PyResult MarketProxyService::PlaceCharOrder(PyCallArgs &call, PyInt* stationID, 
 
             // make sure the user has permissions to take money from the corporation account
             if (
-                    (accountKey == 1000 && (corpRole & Corp::Role::AccountCanTake1) == 0) ||
-                    (accountKey == 1001 && (corpRole & Corp::Role::AccountCanTake2) == 0) ||
-                    (accountKey == 1002 && (corpRole & Corp::Role::AccountCanTake3) == 0) ||
-                    (accountKey == 1003 && (corpRole & Corp::Role::AccountCanTake4) == 0) ||
-                    (accountKey == 1004 && (corpRole & Corp::Role::AccountCanTake5) == 0) ||
-                    (accountKey == 1005 && (corpRole & Corp::Role::AccountCanTake6) == 0) ||
-                    (accountKey == 1006 && (corpRole & Corp::Role::AccountCanTake7) == 0)
-                    )
+                (accountKey == 1000 && (corpRole & Corp::Role::AccountCanTake1) == 0) ||
+                (accountKey == 1001 && (corpRole & Corp::Role::AccountCanTake2) == 0) ||
+                (accountKey == 1002 && (corpRole & Corp::Role::AccountCanTake3) == 0) ||
+                (accountKey == 1003 && (corpRole & Corp::Role::AccountCanTake4) == 0) ||
+                (accountKey == 1004 && (corpRole & Corp::Role::AccountCanTake5) == 0) ||
+                (accountKey == 1005 && (corpRole & Corp::Role::AccountCanTake6) == 0) ||
+                (accountKey == 1006 && (corpRole & Corp::Role::AccountCanTake7) == 0)
+            ) {
                 throw UserError("CrpAccessDenied").AddFormatValue ("reason", new PyString ("You do not have access to that wallet"));
+            }
         }
+
 
         // these need a bit more data
         data.contraband = iRef->contraband();   // does this need to check region/system?
@@ -479,29 +561,49 @@ PyResult MarketProxyService::PlaceCharOrder(PyCallArgs &call, PyInt* stationID, 
         float total = price->value() * quantity->value();
         std::string reason = "DESC:  Setting up sell order in ";
         reason += stDataMgr.GetStationName(stationID->value()).c_str();
+
         // get data for computing broker fees
         uint8 lvl = call.client->GetChar()->GetSkillLevel(EvESkill::BrokerRelations);
+
         //call.client->GetChar()->GetStandingModified();
         uint32 stationOwnerID = stDataMgr.GetOwnerID (call.client->GetStationID ());
+
         float ownerStanding = StandingDB::GetStanding (stationOwnerID, call.client->GetCharacterID ());
         float factionStanding = 0.0f;
 
-        if (IsNPCCorp (stationOwnerID))
+        if (IsNPCCorp (stationOwnerID)) {
             factionStanding = StandingDB::GetStanding(sDataMgr.GetCorpFaction (stationOwnerID), call.client->GetCharacterID());
+        }
 
         float fee = EvEMath::Market::BrokerFee(lvl, factionStanding, ownerStanding, total);
         _log(MARKET__DEBUG, "PlaceCharOrder(sell) - %s: Total: %.2f, Fee: %.2f", useCorp->value() ?"Corp":"Player", total, fee);
 
         // take monies and record actions (taxes are paid when item sells)
         if (useCorp->value()) {
-            AccountService::TranserFunds(call.client->GetCorporationID(), stDataMgr.GetOwnerID(stationID->value()), fee, \
-                    reason.c_str(), Journal::EntryType::Brokerfee, 0, accountKey, Account::KeyType::Cash, call.client);
+            AccountService::TransferFunds(
+                call.client->GetCorporationID(),
+                stDataMgr.GetOwnerID(stationID->value()),
+                fee,
+                reason.c_str(),
+                Journal::EntryType::Brokerfee,
+                0,
+                accountKey,
+                Account::KeyType::Cash,
+                call.client
+            );
         } else {
-            AccountService::TranserFunds(call.client->GetCharacterID(), stDataMgr.GetOwnerID(stationID->value()), fee, \
-                    reason.c_str(), Journal::EntryType::Brokerfee, 0, accountKey);
+            AccountService::TransferFunds(
+                call.client->GetCharacterID(),
+                stDataMgr.GetOwnerID(stationID->value()),
+                fee,
+                reason.c_str(),
+                Journal::EntryType::Brokerfee,
+                0,
+                accountKey
+            );
         }
 
-        //store the order in the DB.
+        // store the order in the DB.
         uint32 orderID(MarketDB::StoreOrder(data));
         if (orderID == 0) {
             _log(MARKET__ERROR, "PlaceCharOrder - Failed to record sell order in the DB.");
@@ -510,7 +612,7 @@ PyResult MarketProxyService::PlaceCharOrder(PyCallArgs &call, PyInt* stationID, 
         }
 
         if (iRef->quantity() == quantity->value()) {
-            //take item from seller
+            // take item from seller
             call.client->SystemMgr()->RemoveItemFromInventory(iRef);
             iRef->Delete();
         } else {
@@ -526,7 +628,6 @@ PyResult MarketProxyService::PlaceCharOrder(PyCallArgs &call, PyInt* stationID, 
         sMktMgr.SendOnOwnOrderChanged(call.client, orderID, Market::Action::Add, useCorp->value());
     }
 
-    //returns nothing.
     return nullptr;
 }
 
@@ -550,9 +651,17 @@ PyResult MarketProxyService::ModifyCharOrder(PyCallArgs &call, PyInt* orderID, P
     float money = (price->value() - newPrice->value()) * volRemaining->value();
     std::string reason = "DESC:  Altering Market Order #";
     reason += std::to_string(orderID->value());
-    AccountService::TranserFunds(call.client->GetCharID(), stDataMgr.GetOwnerID(stationID->value()), money,
-                        reason.c_str(), Journal::EntryType::MarketEscrow, orderID->value(),
-                        Account::KeyType::Cash, Account::KeyType::Escrow);
+
+    AccountService::TransferFunds(
+        call.client->GetCharID(),
+        stDataMgr.GetOwnerID(stationID->value()),
+        money,
+        reason.c_str(),
+        Journal::EntryType::MarketEscrow,
+        orderID->value(),
+        Account::KeyType::Cash,
+        Account::KeyType::Escrow
+    );
 
     if (!MarketDB::AlterOrderPrice(orderID->value(), newPrice->value())) {
         _log(MARKET__ERROR, "ModifyCharOrder - Failed to modify price for order #%i.", orderID->value());
@@ -578,9 +687,17 @@ PyResult MarketProxyService::CancelCharOrder(PyCallArgs &call, PyInt* orderID, P
         // send wallet blink event and record the transaction in their journal.
         std::string reason = "DESC:  Canceling Market Order #";
         reason += std::to_string(orderID->value());
-        AccountService::TranserFunds(stDataMgr.GetOwnerID(oInfo.stationID), call.client->GetCharID(), money,
-                                     reason.c_str(), Journal::EntryType::MarketEscrow, orderID->value(),
-                                     Account::KeyType::Escrow, Account::KeyType::Cash);
+
+        AccountService::TransferFunds(
+            stDataMgr.GetOwnerID(oInfo.stationID),
+            call.client->GetCharID(),
+            money,
+            reason.c_str(),
+            Journal::EntryType::MarketEscrow,
+            orderID->value(),
+            Account::KeyType::Escrow,
+            Account::KeyType::Cash
+        );
     } else {
         ItemData idata(oInfo.typeID, ownerStation, locTemp, flagHangar, oInfo.quantity);
         InventoryItemRef iRef = sItemFactory.SpawnItem(idata);

--- a/src/eve-server/planet/Colony.cpp
+++ b/src/eve-server/planet/Colony.cpp
@@ -1033,21 +1033,22 @@ PyRep* Colony::LaunchCommodities(uint32 pinID, std::map< uint16, uint32 >& items
         //take the money, send wallet blink event record the transaction in their journal.
         std::string reason = "DESC:  Launching PI items from ";
         reason += m_pSE->GetName();
-        AccountService::TranserFunds(
-                    m_client->GetCharacterID(),
-                    corpCONCORD,  // pSysMgr->GetSovHolder(),
-                    cost,
-                    reason.c_str(),
-                    Journal::EntryType::PlanetaryExportTax,
-                    m_pSE->GetID(),
-                    Account::KeyType::Cash);
+
+        AccountService::TransferFunds(
+            m_client->GetCharacterID(),
+            corpCONCORD,  // pSysMgr->GetSovHolder(),
+            cost,
+            reason.c_str(),
+            Journal::EntryType::PlanetaryExportTax,
+            m_pSE->GetID(),
+            Account::KeyType::Cash
+        );
     }
 
     return new PyLong(pin->second.lastLaunchTime);
 }
 
-void Colony::PlanetXfer(uint32 spaceportID, std::map< uint32, uint16 > importItems, std::map< uint32, uint16 > exportItems, double taxRate)
-{
+void Colony::PlanetXfer(uint32 spaceportID, std::map< uint32, uint16 > importItems, std::map< uint32, uint16 > exportItems, double taxRate) {
     // import is from CO to planet.  export is from planet to CO
     // this method will make the transfer of items from real to virtual and back as necessary
 
@@ -1110,14 +1111,16 @@ void Colony::PlanetXfer(uint32 spaceportID, std::map< uint32, uint16 > importIte
         //take the money, send wallet blink event record the transaction in their journal.
         std::string reason = "DESC:  Importing items to ";
         reason += m_pSE->GetName();
-        AccountService::TranserFunds(
-                            m_client->GetCharacterID(),
-                            m_pSE->GetCustomsOffice()->GetOwnerID(),
-                            cost,
-                            reason.c_str(),
-                            Journal::EntryType::PlanetaryImportTax,
-                            m_pSE->GetID(),
-                            Account::KeyType::Cash);
+
+        AccountService::TransferFunds(
+            m_client->GetCharacterID(),
+            m_pSE->GetCustomsOffice()->GetOwnerID(),
+            cost,
+            reason.c_str(),
+            Journal::EntryType::PlanetaryImportTax,
+            m_pSE->GetID(),
+            Account::KeyType::Cash
+        );
     }
 
     // reset cost for possible export taxes
@@ -1161,14 +1164,16 @@ void Colony::PlanetXfer(uint32 spaceportID, std::map< uint32, uint16 > importIte
         //take the money, send wallet blink event record the transaction in their journal.
         std::string reason = "DESC:  Exporting items from ";
         reason += m_pSE->GetName();
-        AccountService::TranserFunds(
-                            m_client->GetCharacterID(),
-                            m_pSE->GetCustomsOffice()->GetOwnerID(),
-                            cost,
-                            reason.c_str(),
-                            Journal::EntryType::PlanetaryExportTax,
-                            m_pSE->GetID(),
-                            Account::KeyType::Cash);
+
+        AccountService::TransferFunds(
+            m_client->GetCharacterID(),
+            m_pSE->GetCustomsOffice()->GetOwnerID(),
+            cost,
+            reason.c_str(),
+            Journal::EntryType::PlanetaryExportTax,
+            m_pSE->GetID(),
+            Account::KeyType::Cash
+        );
     }
 
     pin->second.lastLaunchTime = GetFileTimeNow();  // launch cycle time is 60s

--- a/src/eve-server/planet/PlanetMgr.cpp
+++ b/src/eve-server/planet/PlanetMgr.cpp
@@ -74,13 +74,13 @@ PyRep* PlanetMgr::UpdateNetwork(PyList* commandList)
     return m_colony->GetColony();
 }
 
-bool PlanetMgr::UpgradeCommandCenter(UUNCommand& nc)
-{
+bool PlanetMgr::UpgradeCommandCenter(UUNCommand& nc) {
     // the return here is used to cancel loop in UpdateNetwork.  return false = continue
 
     int8 oldLevel = m_colony->GetLevel(), newLevel = (int8)PyRep::IntegerValue(nc.command_data->GetItem(1));
     int32 cost = 0;
     using namespace PI::Pin;
+
     while (oldLevel != newLevel) {
         //  calculate total upgrade cost in cases where upgrading multiple levels at once
         switch (oldLevel) {
@@ -92,47 +92,55 @@ bool PlanetMgr::UpgradeCommandCenter(UUNCommand& nc)
         }
         ++oldLevel;
     }
+
     //take the money, send wallet blink event record the transaction in their journal.
     std::string reason = "DESC:  Command Center upgrade on ";
     reason += m_planet->GetName();
     uint32 ownerID = corpCONCORD;
-    if (m_planet->SystemMgr()->GetSystemSecurityRating() < 0.5)
+
+    if (m_planet->SystemMgr()->GetSystemSecurityRating() < 0.5) {
         ownerID = corpInterbus;
-    AccountService::TranserFunds(
-                    m_client->GetCharacterID(),
-                    ownerID,  // concord in empire, interbus otherwise
-                    cost,
-                    reason.c_str(),
-                    Journal::EntryType::PlanetaryConstruction,
-                    m_planet->GetID(),
-                    Account::KeyType::Cash);
+    }
+
+    AccountService::TransferFunds(
+        m_client->GetCharacterID(),
+        ownerID,  // concord in empire, interbus otherwise
+        cost,
+        reason.c_str(),
+        Journal::EntryType::PlanetaryConstruction,
+        m_planet->GetID(),
+        Account::KeyType::Cash
+    );
 
     m_colony->UpgradeCommandCenter(PyRep::IntegerValue(nc.command_data->GetItem(0)), newLevel);
     return false;
 }
 
-bool PlanetMgr::CreatePin(UUNCommand& nc)
-{
+bool PlanetMgr::CreatePin(UUNCommand& nc) {
     // the return here is used to break out of loop if needed.  return false = continue
     using namespace EVEDB::invGroups;
     uint32 typeID = PyRep::IntegerValueU32(nc.command_data->GetItem(1));
     uint32 groupID = sItemFactory.GetType(typeID)->groupID();
+
     switch (groupID) {
         case Command_Centers: {
             //take the money, send wallet blink event record the transaction in their journal.
             std::string reason = "DESC:  Command Center construction on ";
             reason += m_planet->GetName();
             uint32 ownerID = corpCONCORD;
-            if (m_planet->SystemMgr()->GetSystemSecurityRating() < 0.5)
+            if (m_planet->SystemMgr()->GetSystemSecurityRating() < 0.5) {
                 ownerID = corpInterbus;
-            AccountService::TranserFunds(
-                        m_client->GetCharacterID(),
-                        ownerID,  // concord in empire, interbus otherwise
-                        90000,
-                        reason.c_str(),
-                        Journal::EntryType::PlanetaryConstruction,
-                        m_planet->GetID(),
-                        Account::KeyType::Cash);
+            }
+
+            AccountService::TransferFunds(
+                m_client->GetCharacterID(),
+                ownerID,  // concord in empire, interbus otherwise
+                90000,
+                reason.c_str(),
+                Journal::EntryType::PlanetaryConstruction,
+                m_planet->GetID(),
+                Account::KeyType::Cash
+            );
 
             UUNCCommandCenter uunccc;
             if (!uunccc.Decode(nc.command_data)) {
@@ -232,22 +240,25 @@ bool PlanetMgr::CreatePin(UUNCommand& nc)
     reason += " Construction on ";
     reason += m_planet->GetName();
     uint32 ownerID = corpCONCORD;
-    if (m_planet->SystemMgr()->GetSystemSecurityRating() < 0.5)
+
+    if (m_planet->SystemMgr()->GetSystemSecurityRating() < 0.5) {
         ownerID = corpInterbus;
-    AccountService::TranserFunds(
-                m_client->GetCharacterID(),
-                ownerID,  // concord in empire, interbus otherwise
-                cost,
-                reason.c_str(),
-                Journal::EntryType::PlanetaryConstruction,
-                m_planet->GetID(),
-                Account::KeyType::Cash);
+    }
+
+    AccountService::TransferFunds(
+        m_client->GetCharacterID(),
+        ownerID,  // concord in empire, interbus otherwise
+        cost,
+        reason.c_str(),
+        Journal::EntryType::PlanetaryConstruction,
+        m_planet->GetID(),
+        Account::KeyType::Cash
+    );
 
     return false;
 }
 
-void PlanetMgr::CreateLink(UUNCommand& nc)
-{
+void PlanetMgr::CreateLink(UUNCommand& nc) {
     uint32 src = 0, dest = 0, level = 0;
     if (nc.command_data->GetItem(0)->IsInt()) {
         if (nc.command_data->GetItem(1)->IsInt()) {

--- a/src/eve-server/ship/Ship.cpp
+++ b/src/eve-server/ship/Ship.cpp
@@ -2489,8 +2489,7 @@ void ShipSE::Process() {
     m_shipRef->ProcessModules();
 }
 
-void ShipSE::DamageRandModule(float chance)
-{
+void ShipSE::DamageRandModule(float chance) {
     if (chance == 0)
         return;
     if (chance > MakeRandomFloat())
@@ -2498,17 +2497,26 @@ void ShipSE::DamageRandModule(float chance)
 }
 
 void ShipSE::PayInsurance() {
-    if (m_self->groupID() == EVEDB::invGroups::Rookieship)
+    if (m_self->groupID() == EVEDB::invGroups::Rookieship) {
         return;
+    }
+
     std::string reason = "Insurance payment for loss of the ship ";
     reason += m_self->itemName();
-    AccountService::TranserFunds(corpSCC, m_ownerID, m_db.GetShipInsurancePayout(m_self->itemID()), \
-            reason, Journal::EntryType::Insurance, m_self->typeID());
+
+    AccountService::TransferFunds(
+        corpSCC,
+        m_ownerID,
+        m_db.GetShipInsurancePayout(m_self->itemID()),
+        reason,
+        Journal::EntryType::Insurance,
+        m_self->typeID()
+    );
+
     ShipDB::DeleteInsuranceByShipID(m_self->itemID());
 }
 
-void ShipSE::ResetShipSystemMgr(SystemManager* pSystem)
-{
+void ShipSE::ResetShipSystemMgr(SystemManager* pSystem) {
     m_system = pSystem;
 }
 

--- a/src/eve-server/station/InsuranceService.cpp
+++ b/src/eve-server/station/InsuranceService.cpp
@@ -173,8 +173,15 @@ PyResult InsuranceBound::InsureShip(PyCallArgs& call, PyInt* shipID, PyFloat* am
         std::string reason = "Insurance Premium on ";
         reason += call.client->GetShip()->itemName();
         reason += ".  Reference ID : xxxxx";     // put contractID here
-        AccountService::TranserFunds(call.client->GetCharacterID(), corpSCC, amount->value(), reason, \
-                Journal::EntryType::Insurance, -shipRef->itemID());     // for paying ins, shipID should be negative
+
+        AccountService::TransferFunds(
+            call.client->GetCharacterID(),
+            corpSCC,
+            amount->value(),
+            reason,
+            Journal::EntryType::Insurance,
+            -shipRef->itemID()
+        );  // for paying ins, shipID should be negative
     } else {
         throw UserError ("InsureShipFailed");
     }

--- a/src/eve-server/station/TradeService.cpp
+++ b/src/eve-server/station/TradeService.cpp
@@ -463,8 +463,8 @@ void TradeBound::ExchangeItems(Client* pClient, Client* pOther, TradeSession* pT
     reason += pOther->GetCharName();
     reason += " in ";
     reason += pClient->GetSystemName();     // use system name or station name here?
-    AccountService::TranserFunds(pClient->GetCharacterID(), pOther->GetCharacterID(), pTSes->m_tradeSession.myMoney, reason, Journal::EntryType::PlayerTrading, pClient->GetStationID());
-    AccountService::TranserFunds(pOther->GetCharacterID(), pClient->GetCharacterID(), pTSes->m_tradeSession.herMoney, reason, Journal::EntryType::PlayerTrading, pClient->GetStationID());
+    AccountService::TransferFunds(pClient->GetCharacterID(), pOther->GetCharacterID(), pTSes->m_tradeSession.myMoney, reason, Journal::EntryType::PlayerTrading, pClient->GetStationID());
+    AccountService::TransferFunds(pOther->GetCharacterID(), pClient->GetCharacterID(), pTSes->m_tradeSession.herMoney, reason, Journal::EntryType::PlayerTrading, pClient->GetStationID());
 
     //PyDict* dict = new PyDict();
     //    dict->SetItem(new PyInt(Inv::Update::Location), new PyInt(pTSes->m_tradeSession.containerID));

--- a/src/eve-server/system/SystemEntity.cpp
+++ b/src/eve-server/system/SystemEntity.cpp
@@ -819,14 +819,14 @@ void DynamicSystemEntity::AwardBounty(Client* pClient)
             reason += pClient->GetName();
             data.reason = reason;
             for (auto cur :members)
-                AccountService::TranserFunds(corpCONCORD, cur, bounty, reason.c_str(), Journal::EntryType::BountyPrize, -GetTypeID());
+                AccountService::TransferFunds(corpCONCORD, cur, bounty, reason.c_str(), Journal::EntryType::BountyPrize, -GetTypeID());
         }
     } else {
         data.amount = bounty;
         if (sConfig.server.BountyPayoutDelayed) {
             m_system->AddBounty(pClient->GetCharacterID(), data);
         } else {
-            AccountService::TranserFunds(corpCONCORD, pClient->GetCharacterID(), bounty, reason.c_str(), Journal::EntryType::BountyPrize, -GetTypeID());
+            AccountService::TransferFunds(corpCONCORD, pClient->GetCharacterID(), bounty, reason.c_str(), Journal::EntryType::BountyPrize, -GetTypeID());
         }
     }
 }

--- a/src/eve-server/system/SystemManager.cpp
+++ b/src/eve-server/system/SystemManager.cpp
@@ -1157,8 +1157,7 @@ void SystemManager::AddMarker(SystemEntity* pSE, bool sendBall/*false*/, bool ad
 }
 
 
-void SystemManager::AddBounty(uint32 charID, BountyData& data)
-{
+void SystemManager::AddBounty(uint32 charID, BountyData& data) {
     /*
 struct BountyData {     // this is comming from rat killed.
     uint32 fromID;
@@ -1196,9 +1195,9 @@ struct BountyData {     // this is comming from rat killed.
     }
 }
 
-void SystemManager::PayBounties()
-{
+void SystemManager::PayBounties() {
     _log(CLIENT__TEXT, "PayBounties called for system %s(%u).", m_data.name.c_str(), m_data.systemID);
+
     int8 count = 0;
         /* recDescNpcBountyList = 'NBL'                <-- descrives a full list of [typeID: qty]
          * recDescNpcBountyListTruncated = 'NBLT'      <-- describes a trunicated list
@@ -1241,11 +1240,14 @@ recStoreItems = 'STOREITEMS'
             }
             // will have to figure out how to *correctly* limit this data to count<20 or so...
         } //else {
-            reason += ",...";    // this will show as "truncated" in client
+
+        reason += ",...";    // this will show as "truncated" in client
         //}
-        AccountService::TranserFunds(corpCONCORD, cur.first, cur.second.amount, reason, Journal::EntryType::BountyPrizes, m_data.systemID);
+
+        AccountService::TransferFunds(corpCONCORD, cur.first, cur.second.amount, reason, Journal::EntryType::BountyPrizes, m_data.systemID);
         count = 0;
     }
+
     m_ratMap.clear();
     m_bountyMap.clear();
 }


### PR DESCRIPTION
**Summary:**

This pull request implements more expected behaviors when doing market transactions. It also implements more support for the NPC traders mentioned throughout the codebase.

It also fixes <https://github.com/EvEmu-Project/evemu_Crucible/issues/96> and <https://github.com/EvEmu-Project/evemu_Crucible/issues/80>:

![2024-09-11-142651_902x335_scrot](https://github.com/user-attachments/assets/0eb4f3a5-3b2e-409f-bc67-4827d7df92a0)

![2024-09-11-142700_904x316_scrot](https://github.com/user-attachments/assets/0516d916-d3ee-473a-bfba-6a8ff4ee1c66)

Additionally, it renames `TranserFunds` to `TransferFunds`, and offers a series of simple code formatting and legibility improvements.

**Also, please accept my apologies for the significant number of files changed in this PR**. I usually try to keep it slim, but this one touched upon a few different areas in the codebase. You'll primarily want to review `MarketProxyService.cpp`, `MarketMgr.cpp`, and `MarketDB.cpp` - almost everything else is unchanged aside from formatting/legibility.

---

**More context/details:**

One of my goals with evemu has been to seed the market with reasonable buyer and seller activity on the market. During code exploration, I discovered reserved trader NPC character IDs including trader joe. I began to seed the market with bidders across different regions using SQL statements, but shortly discovered that market transactions were not behaving as expected. This led me down the rabbit hole that eventually turned into this pull request today.

So - in my experience, during normal usage, I've encountered a few issues regarding market transactions:

1. If a buyer is bidding for 1000 of an item, and you opt to sell 1 item, the code currently will loop and create tons of transactions until the stack is empty. This is different from the expected behavior, where only one sale of one item would have occurred.
2. Market transactions show values of 0 for transactions. <https://github.com/EvEmu-Project/evemu_Crucible/issues/96>
3. Market transactions always show yourself as the client. <https://github.com/EvEmu-Project/evemu_Crucible/issues/80>

The evemu codebase has scattered mentions of "Trader Joe" as well as a range of character ID ranges from 4xxx-5xxxx that allow trader NPC's to essentially "create" market activity. This pull request fleshes out that logic and it seems stable so far on my system.

In order to get NPC traders to work properly within the wallet transactions view, any time a trader NPC's client ID is detected in `MarketDB::GetTransactions`, it is swapped with the current player's ID (only when being sent to the game client) so that the game client's subsequent lookups to resolve information about the entity succeed. Without this step, the server fails to lookup an entity for the trader NPCs and throws an exception. We could discuss better options for this - for example, seeding the database with trader NPCs could possibly help. The actual trader NPC character ID is stored in the database as expected.

As part of this implementation, I found that `characterID` (or `memberID`) for market transactions in the DB was intended to be reserved for corporation transactions. However, the reason for <https://github.com/EvEmu-Project/evemu_Crucible/issues/80> is because each market transaction in the DB does not have an "owner" currently, it only has the `clientID`. I found that there was sufficient room to leverage simple ternary statements (many already existed actually) to determine if an entity is part of a corporation or not using the `isCorp` flags present in the DB - if no corp, then the `characterID` for the market transaction is set to the player's ID, as expected. This allows a proper market transaction history to be associated with an actual character, while still leaving room for corporation-specific logic to exist in the future.

![2024-09-11-144208_1498x199_scrot](https://github.com/user-attachments/assets/304a0fc7-43e6-4ca6-ab76-46665e1fa160)

In the above screenshot, you can see the before/after behavior - `characterID` is `0` before, and after, it is now associated with an actual character.

## Testing

To seed the market, I ran the following SQL - please note that this will delete all market orders in the entire db, as well as resetting the market seed migrations. You'll notice that this is a slightly modified version of the standard market seeding SQL query that ships with the codebase.

This SQL code essentially seeds the market with sellers and buyers. Bidders place orders at a rate of 3% less than the sell to create a profit margin for the buyer, which somewhat emulates a real marketplace.

<details>
<summary><b>Expand here to see SQL that you can copy/paste</b></summary>

```sql
truncate table mktOrders;
truncate table seed_migrations;

use evemu;   -- set this to your db name
-- seeds specified regionID
-- some region ids found in seed_data.sql

set @regionid=10000002; -- the forge
set @saturation=0.1; -- fuzzy logic.  % of stations to fill with orders (random selection)
set @issued=133702393558877328;
set @buyqty=1000000;
set @bidratio=0.97;
set @bidder=4000001; -- trader npc id

-- select stations to fill
create temporary table if not exists tStations (stationId int, solarSystemID int, regionID int, corporationID int, security float);
truncate table tStations;
select round(count(stationID)*@saturation) into @lim from staStations where regionID=@regionid ;
set @i=0;
insert into tStations
  select stationID,solarSystemID,regionID, corporationID, security from staStations where (@i:=@i+1)<=@lim AND regionID=@regionid  order by rand();

-- automated buy orders are also seeded at a loss of 3% always, this allows
-- the game to have an interactive market
INSERT INTO mktOrders (typeID, ownerID, regionID, stationID, orderRange, bid, price, escrow, volEntered, volRemaining, issued,
minVolume, duration, solarSystemID, jumps)
  SELECT typeID, @bidder, regionID, stationID, 0, 1, (basePrice) * @bidratio, (basePrice) * @bidratio * @buyqty, @buyqty, @buyqty, @issued, 1, 90, solarSystemID, 1
  FROM tStations, invTypes inner join invGroups USING (groupID)
  WHERE invTypes.published = 1
  AND invGroups.categoryID IN (4, 5, 6, 7, 8, 9, 16, 17, 18, 22, 23, 24, 25, 32, 34, 35, 39, 40, 41, 42, 43, 46);
-- UPDATE mktOrders SET price = 100 WHERE price = 0;
UPDATE mktOrders SET escrow = 100 WHERE escrow = 0;

-- automated sell orders
INSERT INTO mktOrders (typeID, ownerID, regionID, stationID, price, volEntered, volRemaining, issued,
minVolume, duration, solarSystemID, jumps)
  SELECT typeID, corporationID, regionID, stationID, basePrice, 550, 550, @issued, 1, 250, solarSystemID, 1
  FROM tStations, invTypes inner join invGroups USING (groupID)
  WHERE invTypes.published = 1
  AND invGroups.categoryID IN (4, 5, 6, 7, 8, 9, 16, 17, 18, 22, 23, 24, 25, 32, 34, 35, 39, 40, 41, 42, 43, 46);
UPDATE mktOrders SET price = 100 WHERE price = 0;

insert into seed_migrations (id, applied_at)  values (1, '2024-09-07 17:09:51');
```
</details>

## Test cases

Here are the test cases I did. Where appropriate, I used immediate orders as well as orders of a non-zero duration and fulfilled them on two accounts.

- [x] player buys from static NPC corp
  - [x] market transaction in player's wallet
  - [x] journal transaction in player's wallet
- [x] player sells to trader NPC (but not necessarily trader joe)
  - [x] market transaction in player's wallet
  - [x] journal transaction in player's wallet
- [x] player buys from another player
  - [x] market transaction in seller's wallet
  - [x] journal transaction in seller's wallet
  - [x] market transaction in buyer's wallet
  - [x] journal transaction in buyer's wallet

Corporation transactions are out of scope and are untested due to the fact that the code explicitly forbids a character from doing a corporation transaction at this time.

---

**Other notes**

While making these changes, I found that market results are still cached and do not invalidate upon submitting an order. I wasn't able to figure this one out without increasing the scope of this PR, unfortunately.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Improve market transaction handling by adding support for NPC traders, fixing transaction value and client display issues, and enhancing transaction logic to prevent excessive loops. Rename `TranserFunds` to `TransferFunds` and improve code formatting for better readability.

New Features:
- Implement support for NPC traders in market transactions, allowing them to create market activity and interact with player transactions.

Bug Fixes:
- Fix issue where market transactions showed values of 0, ensuring correct transaction values are displayed.
- Resolve problem where market transactions always showed the player as the client, now correctly identifying the transaction parties.

Enhancements:
- Improve market transaction logic to prevent excessive transaction loops when selling items, ensuring only the intended quantity is sold.
- Rename `TranserFunds` to `TransferFunds` for consistency and clarity across the codebase.
- Enhance code formatting and legibility across multiple files, improving overall code quality.

Tests:
- Add test cases for various market transaction scenarios, including player-to-player and player-to-NPC transactions, to ensure correct wallet and journal entries.

<!-- Generated by sourcery-ai[bot]: end summary -->