### PR TITLE
Ship stop command now executes every time

### DIFF
--- a/src/eve-server/system/DestinyManager.cpp
+++ b/src/eve-server/system/DestinyManager.cpp
@@ -478,21 +478,15 @@ void DestinyManager::UpdateVelocity(bool isMoving) {
     }
 }
 
-//Global Actions:
 void DestinyManager::Stop() {
-    if (m_stop)
-        return;
-
     // AP not implemented yet in this version  -allan 4Mar15
-    //Clear autopilot
-    if (mySE->HasPilot())
+    // Clear autopilot
+    if (mySE->HasPilot()) {
         mySE->GetPilot()->SetAutoPilot(false);
+    }
 
     if (m_userSpeedFraction == 0.0f) {
-        //state is already at stop. but m_stop wasnt set.
-        // set m_stop and return.
         m_stop = true;
-        return;
     } else if  ((m_ballMode == Destiny::Ball::Mode::WARP) and (!IsWarping()))  {
         //warp aborted before initialized.  standard Stop() applies.
         m_ballMode = Destiny::Ball::Mode::STOP;


### PR DESCRIPTION
When in space, the "stop" command works once, but under some conditions it does not work after the first time.

This is because the `m_stop` flag is set to `true` once a stop command is processed, but because it doesn't always get reset back to `false` later, the `Stop()` command just returns early due to its `if (m_stop) return;` check. Unfortunately, the ship continues moving.

Given that Destiny's `Stop()` method seems harmless to repeatedly execute, I've made the change in this PR to remove the `return` statements that were preventing the stop command from triggering if `m_stop` was true.

Now my ship stops as expected in the client.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Ensure the ship stop command executes every time by removing early return conditions in the Stop() method, allowing repeated execution of the stop command.

Bug Fixes:
- Fix the issue where the ship stop command only executes once by removing the early return statements in the Stop() method.

<!-- Generated by sourcery-ai[bot]: end summary -->