### PR TITLE
Active modules now typically consume capacitor charge on initial cycle

### DIFF
--- a/src/eve-server/ship/modules/ActiveModule.cpp
+++ b/src/eve-server/ship/modules/ActiveModule.cpp
@@ -506,8 +506,10 @@ void ActiveModule::DeOverload()
     m_overLoaded = false;
 }
 
-uint32 ActiveModule::DoCycle()
-{
+// `DoCycle` performs checks before activating the module for its next cycle.
+// These checks include applying all capacitor and item consumption
+// requirements.
+uint32 ActiveModule::DoCycle() {
     if (m_destinyMgr == nullptr) {
         // make error for no destiny/bubble
         AbortCycle();
@@ -824,21 +826,16 @@ void ActiveModule::DeactivateCycle(bool abort/*false*/)
 }
 
 void ActiveModule::ProcessActiveCycle() {
-    if (m_Stop)
+    if (m_Stop) {
         SetModuleState(Module::State::Deactivating);
+    }
 
     if (m_ModuleState == Module::State::Deactivating) {
         DeactivateCycle();
         return;
     }
 
-    float newCap = (m_shipRef->GetAttribute(AttrCapacitorCharge).get_float() - GetAttribute(AttrCapacitorNeed)).get_float();
-    if (newCap >= 0 ) {
-        m_shipRef->SetAttribute(AttrCapacitorCharge, newCap);
-        SetTimer(DoCycle());
-    } else {
-        AbortCycle();
-    }
+    SetTimer(DoCycle());
 }
 
 void ActiveModule::SetTimer(uint32 time) {
@@ -1053,8 +1050,7 @@ void ActiveModule::ReprocessCharge()
     m_chargeRef->ClearModifiers();
 }
 
-bool ActiveModule::CanActivate()
-{
+bool ActiveModule::CanActivate() {
     // there is still more to be done here.  wip
     //  modules that require specific tests are coded in their module class, which will call this if their specific checks pass
 
@@ -1070,11 +1066,14 @@ bool ActiveModule::CanActivate()
         }
     }
 
+     // check if ship has sufficient capacitor capacity
     if (m_modRef->HasAttribute(AttrCapacitorNeed)) {
         float remainingCapacitorCharge = m_shipRef->GetAttribute(AttrCapacitorCharge).get_float();
         float requiredCapacitorCharge = GetAttribute(AttrCapacitorNeed).get_float();
 
-        if (requiredCapacitorCharge > remainingCapacitorCharge) {
+        float newCap = remainingCapacitorCharge - requiredCapacitorCharge;
+
+        if (newCap < 0) {
             m_shipRef->GetPilot()->SendNotifyMsg(
                 "This module requires %.0f GJ, but your capacitor only has %.0f GJ remaining.",
                 requiredCapacitorCharge,


### PR DESCRIPTION
Currently, you can repeatedly activate and deactivate a module over and over and it will not consume any capacitor charge. From my testing, this applies to:

- mining modules
- shield boosters
- afterburners
- survey scanners

It probably applies to all currently supported modules in evemu.

It is important to note that _repeating_ a module's active cycle _does_ consume the expected capacitor amount. It's only the initial activation that doesn't seem to consume charge.

This pull request fixes this issue by simply calculating the charge required in order to activate and deducting it from the ship's capacitor as expected.

![2024-09-15-181843_431x355_scrot](https://github.com/user-attachments/assets/971243af-6e82-425d-9060-e7e977cf47be)

Thank you for taking the time to review all of my pull requests :slightly_smiling_face:

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Ensure active modules consume capacitor charge on initial activation by checking and deducting the required charge from the ship's capacitor, preventing activation if insufficient charge is available.

Bug Fixes:
- Fix the issue where active modules do not consume capacitor charge on initial activation by ensuring the required charge is deducted from the ship's capacitor.

<!-- Generated by sourcery-ai[bot]: end summary -->