### PR TITLE
Implement login warp-in and improve translocate commands

### DIFF
--- a/src/eve-common/EVE_Player.h
+++ b/src/eve-common/EVE_Player.h
@@ -54,6 +54,7 @@ namespace Player {
             Uncloak     = 9,
             DriveJump   = 10,
             WormholeJump = 11,
+            LoginWarp = 12,
         };
     }
 }

--- a/src/eve-server/Client.h
+++ b/src/eve-server/Client.h
@@ -203,6 +203,7 @@ public:
     bool SelectCharacter(int32 char_id=0);
     bool IsHangarLoaded(uint32 stationID);
 
+    void UpdateBubble();
     void WarpIn();
     void WarpOut();
     void EnterSystem(uint32 systemID);     // only called by gm command, and only if (bubble == null)
@@ -244,6 +245,7 @@ public:
     bool IsBubbleWait()                                 { return m_bubbleWait; }
     bool IsSetStateSent()                               { return m_setStateSent; }
     bool IsSessionChange()                              { return m_sessionChangeActive; }
+    bool IsLoginWarping();
     uint32 GetSessionChangeTime()                       { return m_sessionTimer.GetRemainingTime() / 1000; }
 
     void SetInvul(bool invul=false)                     { m_invul = invul; }
@@ -251,6 +253,7 @@ public:
     void SetBeyonce(bool beyonce=false)                 { m_beyonce = beyonce; }
     void SetUncloak(bool uncloak=false)                 { m_uncloak = uncloak; }
     void SetBubbleWait(bool wait=false)                 { m_bubbleWait = wait; }
+    void SetLoginWarpComplete();
     void SetStateSent(bool set=false)                   { m_setStateSent = set; }
     void SetSessionTimer()                              { m_sessionChangeActive = true; m_sessionTimer.Start(Player::Timer::Session); }
     void SetSessionChange(bool set=false)               { m_sessionChangeActive = set; }
@@ -402,6 +405,10 @@ protected:
     GPoint m_movePoint;
     // dock location in space (absolute)
     GPoint m_dockPoint;
+    // upon login, the player needs to warp to a location, but the warp
+    // has to be queued to the next tick after login events have been processed
+    GPoint m_loginWarpPoint;
+    GPoint m_loginWarpRandomPoint;
 
     std::set<LSCChannel*>   m_channels;    //we do not own these.
     std::map<uint32, bool>  m_hangarLoaded;

--- a/src/eve-server/admin/SystemCommands.cpp
+++ b/src/eve-server/admin/SystemCommands.cpp
@@ -4,10 +4,12 @@
  *
  */
 
+#include "EVE_Defines.h"
 #include "eve-server.h"
 
 #include "Client.h"
 #include "ConsoleCommands.h"
+#include "log/logsys.h"
 #include "npc/NPC.h"
 #include "npc/NPCAI.h"
 #include "admin/AllCommands.h"
@@ -48,6 +50,36 @@ PyResult Command_goto(Client* pClient, CommandDB* db, EVEServiceManager &service
 
 PyResult Command_translocate(Client* pClient, CommandDB* db, EVEServiceManager &services, const Seperator& args) {
     return Command_tr(pClient,db,services,args);
+}
+
+// `UpdateBubble` is a reusable function that synchronizes the player's position
+// and ensures that their bubble exists.
+static PyResult UpdateBubble(Client *pClient) {
+    if (!pClient->IsInSpace())
+        throw CustomError ("You're not in space.");
+    if (pClient->GetShipSE()->DestinyMgr() == nullptr)
+        pClient->SetDestiny(NULL_ORIGIN);
+    if (pClient->GetShipSE()->SysBubble() == nullptr)
+        pClient->EnterSystem(pClient->GetSystemID());
+    if (pClient->IsSessionChange()) {
+        pClient->SendInfoModalMsg("Session Change Active.  Wait %u seconds before issuing another command.",
+                                  pClient->GetSessionChangeTime());
+        return new PyString("SessionChange Active.  Request Denied.");
+    }
+
+    pClient->GetShipSE()->DestinyMgr()->SetPosition(pClient->GetShipSE()->GetPosition(), true);
+
+    SystemBubble *pBubble = pClient->GetShipSE()->SysBubble();
+    if (pBubble == nullptr) {
+        sBubbleMgr.Add(pClient->GetShipSE());
+        pBubble = pClient->GetShipSE()->SysBubble();
+    }
+    pBubble->SendAddBalls(pClient->GetShipSE());
+
+    pClient->SetStateSent(false);
+    pClient->GetShipSE()->DestinyMgr()->SendSetState();
+    pClient->SetSessionTimer();
+    return new PyString("Update sent.");
 }
 
 /*   hardcoded menu translocates in client
@@ -393,9 +425,45 @@ PyResult Command_tr(Client* pClient, CommandDB* db, EVEServiceManager &services,
                 locationID = pClient2->GetSystemID();
             }
         }
-    }
-    //  connect to dataMgrs for location verification
-    else if (!sDataMgr.IsStation(locationID) and !sDataMgr.IsSolarSystem(locationID)) {
+    } else if (IsCelestialID(locationID) || IsStargateID(locationID) || IsSolarSystemID(locationID)) {
+        // This section of code primarily governs the behavior of clicking
+        // "TR me here" in the in-game client menus, for things like asteroid
+        // belts, planets, stargates, etc.
+
+        // As of 2024-09-15, translocating is overall still a bit buggy. When
+        // switching solar systems, the client may sometimes be unable to
+        // navigate even though the position may be fine upon next login. Could
+        // this be solvable by calling UpdateBubble()?
+
+        DBQueryResult res;
+        DBResultRow row;
+
+        if (!sDatabase.RunQuery(res, "SELECT solarSystemID, x,y,z FROM mapDenormalize WHERE itemID = %i LIMIT 1;", locationID)) {
+            codelog(DATABASE__ERROR, "Error in query: %s", res.error.c_str());
+            throw CustomError ("Translocate: Unable to find celestial location %i", locationID);
+        }
+
+        if (!res.GetRow(row)) {
+            throw CustomError("Translocate: No data for celestial location %i", locationID);
+        }
+
+        if (pClient->IsDocked()) {
+            pClient->UndockFromStation();
+        }
+
+        if (IsSolarSystemID(locationID)) {
+            // translocate to the solar system's star directly
+            pt.x = 0;
+            pt.y = 0;
+            pt.z = 0;
+        } else {
+            locationID = row.GetInt(0);
+            pt.x = row.GetDouble(1);
+            pt.y = row.GetDouble(2);
+            pt.z = row.GetDouble(3);
+        }
+    } else if (!sDataMgr.IsStation(locationID) and !sDataMgr.IsSolarSystem(locationID)) {
+        // connect to dataMgrs for location verification
         throw CustomError ("Translocate: Invalid Location %i", locationID);
     }
 
@@ -403,11 +471,28 @@ PyResult Command_tr(Client* pClient, CommandDB* db, EVEServiceManager &services,
         pOtherClient->JumpOutEffect(pOtherClient->GetLocationID());
         pOtherClient->MoveToLocation(locationID, pt);
         pOtherClient->JumpInEffect();
+        if (pOtherClient->IsInSpace()) {
+            pOtherClient->GetShipSE()->DestinyMgr()->Stop();
+            UpdateBubble(pOtherClient);
+        }
+
+        // translocating can interrupt the login warp bubble, leaving the
+        // player unable to do anything
+        pOtherClient->SetLoginWarpComplete();
     } else {
         pClient->JumpOutEffect(myLocationID);
         pClient->MoveToLocation(locationID, pt);
         pClient->JumpInEffect();
+        if (pClient->IsInSpace()) {
+            pClient->GetShipSE()->DestinyMgr()->Stop();
+            UpdateBubble(pClient);
+        }
+
+        // translocating can interrupt the login warp bubble, leaving the
+        // player unable to do anything
+        pClient->SetLoginWarpComplete();
     }
+
     return nullptr;
 }
 
@@ -839,32 +924,9 @@ PyResult Command_syncpos(Client* pClient, CommandDB* db, EVEServiceManager &serv
     return new PyString("All Positions synchronized.");
 }
 
+
 PyResult Command_update(Client *pClient, CommandDB *db, EVEServiceManager &services, const Seperator &args) {
-    if (!pClient->IsInSpace())
-        throw CustomError ("You're not in space.");
-    if (pClient->GetShipSE()->DestinyMgr() == nullptr)
-        pClient->SetDestiny(NULL_ORIGIN);
-    if (pClient->GetShipSE()->SysBubble() == nullptr)
-        pClient->EnterSystem(pClient->GetSystemID());
-    if (pClient->IsSessionChange()) {
-        pClient->SendInfoModalMsg("Session Change Active.  Wait %u seconds before issuing another command.",
-                                  pClient->GetSessionChangeTime());
-        return new PyString("SessionChange Active.  Request Denied.");
-    }
-
-    pClient->GetShipSE()->DestinyMgr()->SetPosition(pClient->GetShipSE()->GetPosition(), true);
-
-    SystemBubble *pBubble = pClient->GetShipSE()->SysBubble();
-    if (pBubble == nullptr) {
-        sBubbleMgr.Add(pClient->GetShipSE());
-        pBubble = pClient->GetShipSE()->SysBubble();
-    }
-    pBubble->SendAddBalls(pClient->GetShipSE());
-
-    pClient->SetStateSent(false);
-    pClient->GetShipSE()->DestinyMgr()->SendSetState();
-    pClient->SetSessionTimer();
-    return new PyString("Update sent.");
+    return UpdateBubble(pClient);
 }
 
 PyResult Command_sendstate(Client *pClient, CommandDB *db, EVEServiceManager &services, const Seperator &args) {

--- a/src/eve-server/ship/BeyonceService.cpp
+++ b/src/eve-server/ship/BeyonceService.cpp
@@ -131,6 +131,8 @@ PyResult BeyonceBound::CmdFollowBall(PyCallArgs &call, PyInt* ballID, PyRep* dis
     } else if (pDestiny->IsFrozen()) {
         call.client->SendNotifyMsg( "Your ship is frozen and cannot move");
         return PyStatic.NewNone();
+    }  else if (pDestiny->AbortIfLoginWarping(true)) {
+        return PyStatic.NewNone();
     }
     SystemManager* pSystem = call.client->SystemMgr();
     if (pSystem == nullptr) {
@@ -162,6 +164,8 @@ PyResult BeyonceBound::CmdSetSpeedFraction(PyCallArgs &call, PyFloat* speedFract
     } else if (pDestiny->IsFrozen()) {
         call.client->SendNotifyMsg( "Your ship is frozen and cannot move");
         return PyStatic.NewNone();
+    }  else if (pDestiny->AbortIfLoginWarping(true)) {
+        return PyStatic.NewNone();
     }
 
     /** @todo  rework this...this is to set speed ONLY...NOT to begin moving.  */
@@ -189,6 +193,8 @@ PyResult BeyonceBound::CmdAlignTo(PyCallArgs &call, PyInt* entityID) {
         return PyStatic.NewNone();
     } else if (pDestiny->IsWarping()) {
         call.client->SendNotifyMsg( "You can't do this while warping");
+        return PyStatic.NewNone();
+    }  else if (pDestiny->AbortIfLoginWarping(true)) {
         return PyStatic.NewNone();
     } else if (pDestiny->IsFrozen()) {
         call.client->SendNotifyMsg( "Your ship is frozen and cannot move");
@@ -224,6 +230,8 @@ PyResult BeyonceBound::CmdGotoDirection(PyCallArgs &call, PyFloat* x, PyFloat* y
         return PyStatic.NewNone();
     } else if (pDestiny->IsWarping()) {
         call.client->SendNotifyMsg( "You can't do this while warping");
+        return PyStatic.NewNone();
+    } else if (pDestiny->AbortIfLoginWarping(true)) {
         return PyStatic.NewNone();
     } else if (pDestiny->IsFrozen()) {
         call.client->SendNotifyMsg( "Your ship is frozen and cannot move");
@@ -302,6 +310,8 @@ PyResult BeyonceBound::CmdOrbit(PyCallArgs &call, PyInt* entityID, PyRep* rangeV
     } else if (pDestiny->IsWarping()) {
         call.client->SendNotifyMsg( "You can't do this while warping");
         return PyStatic.NewNone();
+    }  else if (pDestiny->AbortIfLoginWarping(true)) {
+        return PyStatic.NewNone();
     } else if (pDestiny->IsFrozen()) {
         call.client->SendNotifyMsg( "Your ship is frozen and cannot move");
         return PyStatic.NewNone();
@@ -351,6 +361,8 @@ PyResult BeyonceBound::CmdWarpToStuff(PyCallArgs &call, PyString* type, PyRep* i
     }
     if (pDestiny->IsWarping()){
         call.client->SendNotifyMsg( "You are already warping");
+        return PyStatic.NewNone();
+    }  else if (pDestiny->AbortIfLoginWarping(true)) {
         return PyStatic.NewNone();
     } else if (pDestiny->IsFrozen()) {
         call.client->SendNotifyMsg( "Your ship is frozen and cannot move");
@@ -577,6 +589,8 @@ PyResult BeyonceBound::CmdWarpToStuffAutopilot(PyCallArgs &call, PyInt* destID) 
     } else if (pDestiny->IsWarping()) {
         call.client->SendNotifyMsg( "You can't do this while warping");
         return PyStatic.NewNone();
+    }  else if (pDestiny->AbortIfLoginWarping(true)) {
+        return PyStatic.NewNone();
     } else if (pDestiny->IsFrozen()) {
         call.client->SendNotifyMsg( "Your ship is frozen and cannot move");
         return PyStatic.NewNone();
@@ -623,6 +637,8 @@ PyResult BeyonceBound::CmdStop(PyCallArgs &call) {
     if (pDestiny->IsWarping()) {
         call.client->SendNotifyMsg( "You can't do this while warping");
         return PyStatic.NewNone();
+    }  else if (pDestiny->AbortIfLoginWarping(true)) {
+        return PyStatic.NewNone();
     } else if (pDestiny->IsFrozen()) {
         call.client->SendNotifyMsg( "Your ship is frozen and cannot move");
         return PyStatic.NewNone();
@@ -649,6 +665,8 @@ PyResult BeyonceBound::CmdDock(PyCallArgs &call, PyInt* celestialID, PyInt* ship
         return PyStatic.NewNone();
     } else if (pDestiny->IsWarping()) {
         call.client->SendNotifyMsg( "You can't do this while warping");
+        return PyStatic.NewNone();
+    }  else if (pDestiny->AbortIfLoginWarping(true)) {
         return PyStatic.NewNone();
     } else if (pDestiny->IsFrozen()) {
         call.client->SendNotifyMsg( "Your ship is frozen and cannot move");
@@ -704,6 +722,8 @@ PyResult BeyonceBound::CmdStargateJump(PyCallArgs &call, PyInt* fromStargateID, 
         return PyStatic.NewNone();
     } else if (pDestiny->IsWarping()) {
         call.client->SendNotifyMsg( "You can't do this while warping");
+        return PyStatic.NewNone();
+    }  else if (pDestiny->AbortIfLoginWarping(true)) {
         return PyStatic.NewNone();
     } else if (pDestiny->IsFrozen()) {
         call.client->SendNotifyMsg( "Your ship is frozen and cannot move");
@@ -769,6 +789,8 @@ PyResult BeyonceBound::UpdateStateRequest(PyCallArgs &call) {
     }
     if (pDestiny->IsWarping()) {
         call.client->SendNotifyMsg( "You can't do this while warping");
+        return PyStatic.NewNone();
+    }  else if (pDestiny->AbortIfLoginWarping(true)) {
         return PyStatic.NewNone();
     }
 
@@ -892,6 +914,8 @@ PyResult BeyonceBound::CmdJumpThroughCorporationStructure(PyCallArgs &call, PyIn
     } else if (pDestiny->IsWarping()) {
         call.client->SendNotifyMsg( "You can't do this while warping");
         return PyStatic.NewNone();
+    }  else if (pDestiny->AbortIfLoginWarping(true)) {
+        return PyStatic.NewNone();
     }
 
     InventoryItemRef beacon = sItemFactory.GetItemRefFromID(remoteStructureID->value());
@@ -965,6 +989,8 @@ PyResult BeyonceBound::CmdBeaconJumpFleet(PyCallArgs &call, PyInt* characterID, 
         return PyStatic.NewNone();
     } else if (pDestiny->IsFrozen()) {
         call.client->SendNotifyMsg( "Your ship is frozen and cannot move");
+        return PyStatic.NewNone();
+    }  else if (pDestiny->AbortIfLoginWarping(true)) {
         return PyStatic.NewNone();
     }
 
@@ -1047,6 +1073,8 @@ PyResult BeyonceBound::CmdBeaconJumpAlliance(PyCallArgs &call, PyInt* beaconID, 
         return PyStatic.NewNone();
     } else if (pDestiny->IsWarping()) {
         call.client->SendNotifyMsg( "You can't do this while warping");
+        return PyStatic.NewNone();
+    }  else if (pDestiny->AbortIfLoginWarping(true)) {
         return PyStatic.NewNone();
     }
 

--- a/src/eve-server/system/DestinyManager.h
+++ b/src/eve-server/system/DestinyManager.h
@@ -221,6 +221,9 @@ public:
     bool IsFrozen()                                     { return m_frozen; }
     void SetFrozen(bool set=false)                      { m_frozen = set; }
 
+    // Prevents actions if the player is performing the login warp
+    bool AbortIfLoginWarping(bool showMsg);
+
 protected:
     void ProcessState();
 


### PR DESCRIPTION
This pull request brings in the following changes:

1. An implementation of login warp-in from 0.5 AU
2. Improvements to the translocate command (menus in space now work for belts/planets/etc)

---

**Details about the first change: Login warp-in**

I tried to leave good comments in the code to describe everything that went into this, but I'll provide a bit of an explanation here as well.

Currently (before this PR), the behavior on in-space login that I see is that the universe is just a black void, or sometimes is an unpopulated and inaccessible solar system.

I was able to verify that the client is actually just out of sync with the server - you can actually just call `/sendstate` right after you log in, and the client is now synchronized with the server and you can do regular things.

`/sendstate` essentially uses `UpdateBubble()` to synchronize the client & server. I used this logic as the foundation for fixing the login warp functionality.

As explained in the code, the new login warp cloaks and moves the player to a position 0.5 AU away from their last logout position. `UpdateBubble()` is called so that a bubble is created before the player's upcoming warp vector gets established.

The client's state is set to `Login` and, on the next server tick, the actual Destiny `WarpTo` method gets called, they're uncloaked, and many `Beyonce` player commands are restricted until the warp is completed. This prevents the user from aborting the warp preemptively, which is consistent with expected behavior.

Finally, once the warp completes, the player's `LoginWarp` state is cleared out and they can use their ship again.

**To test this out**, simply:

- [x] log out in space and verify that you spawn 0.5 AU away from your previous point, cloaked.
- [x] try frantically to move in a direction, stop the ship, warp, dock, etc while establishing the login warp vector and confirm you do not succeed.
- [x] log out when docked and confirm that you are still docked when you log back in.

**Known issues**:

The only expected issue I ran into at this time is that sometimes the player's position isn't preserved on log out, so you might end up 0.5 AU away from 0.5 AU away from your original point. This is out of scope for this pull request, because the logout code isn't fully fleshed out, and it's probably related to that.

---

**Details about the second change: Translocate improvements**

I found that when translocating via the solar system menu to e.g. an asteroid belt or planet, the command failed due to an invalid lookup (the code isn't there yet). 

To make it work, I implemented database queries against the `mapDenormalize` table to resolve celestials and use their spatial coordinates for translocation. It's not perfect - it will teleport you to the center of planets and moons (can be fixed later easily, I suspect) - but it's good enough for now. It also may not behave perfectly with existing translocation command permutations (fleet, other players, etc), but the number of testing permutations is significant enough such that I cannot realistically test them all.

I bundled in the translocation command fixes with the warp-on-login changes because if you translocate in the middle of a login warp bubble before it collapses, the "warp complete" event never triggers, and thus the newly added login warp state values are never reset - meaning you will never be able to do anything with your ship for the whole client session (probably). This is an edge case that can only ever happen due to a translocation command.

Another edge case: If you translocate to a solar system (typically doable from the star map), translocating to 0,0,0 was buggy, so instead I query for the celestial that has the smallest `x` value for simplicity.

**To test this**:

- [x] right click in space -> translocate to a belt, planet, moon, or other non-station celestial and verify that it works
- [x] same thing, but with a station
- [x] open the star map and translocate to a system. Confirm that you are translocated to the celestial that has the lowest `x` value and not the star.

---

Thanks for reading/reviewing!

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Introduce a login warp-in feature that synchronizes the client and server upon player login, moving the player to a safe distance and restricting actions until warp completion. Enhance the translocate command to work with celestial objects by resolving their spatial coordinates, improving the overall user experience when navigating through space.

New Features:
- Implement login warp-in functionality that moves players to a position 0.5 AU away from their last logout position, cloaked, and restricts certain actions until the warp is completed.

Enhancements:
- Improve the translocate command to support menus in space for belts, planets, and other celestial objects by implementing database queries to resolve spatial coordinates.

<!-- Generated by sourcery-ai[bot]: end summary -->