### PR TITLE
Use double for destiny m_targetDistance instead of uint32

### DIFF
--- a/src/eve-server/admin/SystemCommands.cpp
+++ b/src/eve-server/admin/SystemCommands.cpp
@@ -930,21 +930,42 @@ PyResult Command_update(Client *pClient, CommandDB *db, EVEServiceManager &servi
 }
 
 PyResult Command_sendstate(Client *pClient, CommandDB *db, EVEServiceManager &services, const Seperator &args) {
-    if (!pClient->IsInSpace())
+    _log(COMMAND__MESSAGE, "SystemCommands::SendState() - checking if in space");
+    if (!pClient->IsInSpace()) {
         throw CustomError ("You're not in space.");
-    if (pClient->GetShipSE()->DestinyMgr() == nullptr)
-        pClient->SetDestiny(NULL_ORIGIN);
-    if (pClient->GetShipSE()->SysBubble() == nullptr)
-        pClient->EnterSystem(pClient->GetSystemID());
-    if (pClient->IsSessionChange()) {
-        pClient->SendInfoModalMsg("Session Change Active.  Wait %u seconds before issuing another command.",
-                                  pClient->GetSessionChangeTime());
-        return new PyString("SessionChange Active.  Request Denied.");
     }
 
+    _log(COMMAND__MESSAGE, "SystemCommands::SendState() - checking if destiny manager is null");
+    if (pClient->GetShipSE()->DestinyMgr() == nullptr) {
+        _log(COMMAND__MESSAGE, "SystemCommands::SendState() - destiny manager is null, setting to null origin");
+        pClient->SetDestiny(NULL_ORIGIN);
+    }
+
+    _log(COMMAND__MESSAGE, "SystemCommands::SendState() - checking if bubble is null");
+    if (pClient->GetShipSE()->SysBubble() == nullptr) {
+        _log(COMMAND__MESSAGE, "SystemCommands::SendState() - bubble is null, setting system id");
+        pClient->EnterSystem(pClient->GetSystemID());
+    }
+
+    _log(COMMAND__MESSAGE, "SystemCommands::SendState() - checking if session is changing");
+    if (pClient->IsSessionChange()) {
+        pClient->SendInfoModalMsg(
+            "Session Change Active. Wait %u seconds before issuing another command.",
+            pClient->GetSessionChangeTime()
+        );
+
+        return new PyString("SessionChange Active. Request Denied.");
+    }
+
+    _log(COMMAND__MESSAGE, "SystemCommands::SendState() - setting state sent to false");
     pClient->SetStateSent(false);
+
+    _log(COMMAND__MESSAGE, "SystemCommands::SendState() - sending SetState");
     pClient->GetShipSE()->DestinyMgr()->SendSetState();
+
+    _log(COMMAND__MESSAGE, "SystemCommands::SendState() - setting session timer");
     pClient->SetSessionTimer();
+
     return new PyString("Update sent.");
 }
 

--- a/src/eve-server/system/DestinyManager.cpp
+++ b/src/eve-server/system/DestinyManager.cpp
@@ -32,6 +32,7 @@
 #include "EntityList.h"
 
 #include "StaticDataMgr.h"
+#include "log/logsys.h"
 #include "map/MapData.h"
 #include "math/Trig.h"
 #include "npc/NPC.h"
@@ -46,6 +47,7 @@
 #include "system/DestinyManager.h"
 #include "system/SystemBubble.h"
 #include "system/SystemManager.h"
+#include <cstdlib>
 
 
 DestinyManager::DestinyManager(SystemEntity *self)
@@ -227,9 +229,8 @@ void DestinyManager::ProcessState() {
                 m_shipHeading = toVec;
                 InitWarp();
                 return;
-            } else if (m_timeFraction < 0.749) {
-                if (m_userSpeedFraction < 0.7499)
-                    SetSpeedFraction(1.0f, true);
+            } else if (m_timeFraction < 0.749 && m_userSpeedFraction < 0.7499) {
+                SetSpeedFraction(1.0f, true);
             } else if ((sEntityList.GetStamp() - m_stateStamp) > m_timeToEnterWarp + 0.3) {
                 // catchall for turn checks messed up, and m_moveTime > ship align time
                 if (mySE->HasPilot()) {
@@ -1474,15 +1475,22 @@ void DestinyManager::InitWarp() {
      * the client seems to accept and agree with the math here.
      */
     // reset turn variables for warping
-    if (m_turning)
+    if (m_turning) {
         ClearTurn();
+    }
 
-    if (is_log_enabled(DESTINY__WARP_TRACE))
-        _log(DESTINY__WARP_TRACE, "Destiny::InitWarp(): %s(%u) has initialized warp.", mySE->GetName(), mySE->GetID());
+    if (is_log_enabled(DESTINY__WARP_TRACE)) {
+        _log(
+            DESTINY__WARP_TRACE,
+            "Destiny::InitWarp(): %s(%u) has initialized warp.",
+            mySE->GetName(),
+            mySE->GetID()
+        );
+    }
 
-    double warpSpeedInMeters(m_shipWarpSpeed * ONE_AU_IN_METERS);
+    double warpSpeedInMeters(static_cast<double>(m_shipWarpSpeed) * static_cast<double>(ONE_AU_IN_METERS));
 
-    /*  this is from http://community.eveonline.com/news/dev-blogs/warp-drive-active/
+    /* this is from http://community.eveonline.com/news/dev-blogs/warp-drive-active/
      * x = e^(k*t)
      * v = k*e^(k*t)
      *
@@ -1492,69 +1500,129 @@ void DestinyManager::InitWarp() {
      * k = 3 for accel, 1 for decel
      *
      * this gives distances as functions of time.
-     *  the client seems to agree with this reasoning, and follows the same idea.
+     * the client seems to agree with this reasoning, and follows the same idea.
      */
 
     bool cruise(true);
     float cruiseTime(0.0f);
     double accelDistance(0.0), decelDistance(0.0), cruiseDistance(0.0);
     // fudge this a bit for accel/decel distances
-    if (m_targetDistance < warpSpeedInMeters) {
-        //  short warp....no cruise
+    if (abs(static_cast<double>(m_targetDistance)) < warpSpeedInMeters) {
+        _log(
+            DESTINY__WARP_TRACE,
+            "short warp distance dictates that warp cruise time is unnecessary"
+        );
+
+        // short warp....no cruise
         // this isnt very accurate....times and distances are a bit off....
         cruise = false;
         // accel = 1/3 decel
-        accelDistance = (m_targetDistance / 3);
-        decelDistance = (m_targetDistance - accelDistance);
+        accelDistance = (static_cast<double>(m_targetDistance) / static_cast<double>(3));
+        decelDistance = (static_cast<double>(m_targetDistance) - accelDistance);
         warpSpeedInMeters = accelDistance;
-        m_warpDecelTime = log(decelDistance / 3);
-        m_warpAccelTime = log(accelDistance / 3) / 3;
+        m_warpDecelTime = log(decelDistance / static_cast<double>(3));
+        m_warpAccelTime = log(accelDistance / static_cast<double>(3)) / static_cast<double>(3);
     } else {
+        _log(
+            DESTINY__WARP_TRACE,
+            "longer warp distance dictates that warp cruise time is is warranted"
+        );
+
         // all ships base time is 29s for distances > ship warp speed
         m_warpAccelTime = 7;
         m_warpDecelTime = 21; // accel *3
-        decelDistance = exp(m_warpDecelTime);   // ship warp speed in meters * 1.7
-        accelDistance = exp(3 * m_warpAccelTime);       // ship warp speed in meters
-        cruiseDistance = (m_targetDistance - accelDistance - decelDistance);
-        cruiseTime = (cruiseDistance / warpSpeedInMeters);
+        decelDistance = exp(static_cast<double>(m_warpDecelTime));   // ship warp speed in meters * 1.7
+        accelDistance = exp(static_cast<double>(3) * static_cast<double>(m_warpAccelTime));       // ship warp speed in meters
+        cruiseDistance = (static_cast<double>(m_targetDistance) - accelDistance - decelDistance);
+        cruiseTime = static_cast<float>(cruiseDistance / warpSpeedInMeters);
     }
 
     //  set total warp time based on above math.
-    float warpTime(m_warpAccelTime + m_warpDecelTime + std::floor(cruiseTime));
+    float warpTime(static_cast<float>(m_warpAccelTime) + static_cast<float>(m_warpDecelTime) + std::floor(cruiseTime));
 
     GVector warp_vector(m_position, m_targetPoint);
     warp_vector.normalize();
 
     if (is_log_enabled(DESTINY__WARP_TRACE)) {
-        _log(DESTINY__WARP_TRACE, "Destiny::InitWarp():Calculate - %s(%u): Warp will accelerate for %us, cruise for %.3f, then decelerate for %us, with total time of %.3fs, and warp speed of %.4f m/s.", \
-            mySE->GetName(), mySE->GetID(), m_warpAccelTime, cruiseTime, m_warpDecelTime, warpTime, warpSpeedInMeters);
-        _log(DESTINY__WARP_TRACE, "Destiny::InitWarp():Calculate - %s(%u): Accel distance is %.4f. Cruise distance is %.4f.  Decel distance is %.4f.  Direction is %.3f,%.3f,%.3f.", \
-            mySE->GetName(), mySE->GetID(), accelDistance, cruiseDistance, decelDistance, warp_vector.x, warp_vector.y, warp_vector.z);
-        _log(DESTINY__WARP_TRACE, "Destiny::InitWarp():Calculate - %s(%u): We will exit warp at %.2f,%.2f,%.2f at a distance of %.4f AU (%um).", \
-            mySE->GetName(), mySE->GetID(), m_targetPoint.x, m_targetPoint.y, m_targetPoint.z, m_targetDistance/ONE_AU_IN_METERS, m_targetDistance);
+        _log(
+            DESTINY__WARP_TRACE,
+            "Destiny::InitWarp():Calculate - %s(%u): Warp will accelerate for %us, cruise for %.3f, then decelerate for %us, with total time of %.3fs, and warp speed of %.4f m/s.",
+            mySE->GetName(),
+            mySE->GetID(),
+            m_warpAccelTime,
+            cruiseTime,
+            m_warpDecelTime,
+            warpTime,
+            warpSpeedInMeters
+        );
+
+        _log(
+            DESTINY__WARP_TRACE,
+            "Destiny::InitWarp():Calculate - %s(%u): Accel distance is %.4f. Cruise distance is %.4f.  Decel distance is %.4f.  Direction is %.3f,%.3f,%.3f.",
+            mySE->GetName(),
+            mySE->GetID(),
+            accelDistance,
+            cruiseDistance,
+            decelDistance,
+            warp_vector.x,
+            warp_vector.y,
+            warp_vector.z
+        );
+
+        _log(
+            DESTINY__WARP_TRACE,
+            "Destiny::InitWarp():Calculate - %s(%u): We will exit warp at %.2f,%.2f,%.2f at a distance of %.4f AU (%.2fm).",
+            mySE->GetName(),
+            mySE->GetID(),
+            m_targetPoint.x,
+            m_targetPoint.y,
+            m_targetPoint.z,
+            static_cast<double>(m_targetDistance)/static_cast<double>(ONE_AU_IN_METERS),
+            static_cast<double>(m_targetDistance)
+        );
+
         GPoint destination = m_position + (warp_vector * m_targetDistance);
-        _log(DESTINY__WARP_TRACE, "Destiny::InitWarp():Calculate - %s(%u): calculated exit is %.2f,%.2f,%.2f and vector is %.4f,%.4f,%.4f.", \
-            mySE->GetName(), mySE->GetID(), destination.x, destination.y, destination.z, warp_vector.x, warp_vector.y, warp_vector.z);
+        _log(
+            DESTINY__WARP_TRACE,
+            "Destiny::InitWarp():Calculate - %s(%u): calculated exit is %.2f,%.2f,%.2f and vector is %.4f,%.4f,%.4f.",
+            mySE->GetName(),
+            mySE->GetID(),
+            destination.x,
+            destination.y,
+            destination.z,
+            warp_vector.x,
+            warp_vector.y,
+            warp_vector.z
+        );
+
         GVector diff(m_targetPoint, destination);
-        _log(DESTINY__WARP_TRACE, "Destiny::InitWarp():Calculate - target vs calculated is %.2fm.", diff.length());
+        _log(
+            DESTINY__WARP_TRACE,
+            "Destiny::InitWarp():Calculate - target vs calculated is %.2fm, and m_targetDistance is %.2f m.",
+            diff.length(),
+            m_targetDistance
+        );
     }
-    //  reset deceltime (from duration to time) for time check in WarpDecel()
+
+    // reset deceltime (from duration to time) for time check in WarpDecel()
     m_warpDecelTime = m_warpAccelTime + floor(cruiseTime);
     m_stateStamp = sEntityList.GetStamp();
 
     SafeDelete(m_warpState);
+
     m_warpState = new WarpState(
-                        m_stateStamp,
-                        m_targetDistance,
-                        warpSpeedInMeters,
-                        accelDistance,
-                        cruiseDistance,
-                        decelDistance,
-                        warpTime,
-                        true,
-                        false,
-                        false,
-                        warp_vector );
+        m_stateStamp,
+        m_targetDistance,
+        warpSpeedInMeters,
+        accelDistance,
+        cruiseDistance,
+        decelDistance,
+        warpTime,
+        true,
+        false,
+        false,
+        warp_vector
+    );
 
     //drain cap
     if (mySE->HasPilot()) {
@@ -1577,14 +1645,19 @@ void DestinyManager::WarpAccel(uint16 sec_into_warp) {
      */
     double currentDistance = exp(3 * sec_into_warp);
 
-    if (mySE->SysBubble() != nullptr)
-        if (currentDistance > BUBBLE_RADIUS_METERS)
-            if (mySE->SysBubble() != m_targBubble) {
-                if (is_log_enabled(DESTINY__WARP_TRACE))
-                    _log(DESTINY__WARP_TRACE, "Destiny::WarpAccel(): %s(%u) is being removed from bubble %u.",\
-                            mySE->GetName(), mySE->GetID(), mySE->SysBubble()->GetID());
-                mySE->SysBubble()->Remove(mySE);
-            }
+    if (mySE->SysBubble() != nullptr && currentDistance > BUBBLE_RADIUS_METERS && mySE->SysBubble() != m_targBubble) {
+        if (is_log_enabled(DESTINY__WARP_TRACE)) {
+            _log(
+                DESTINY__WARP_TRACE,
+                "Destiny::WarpAccel(): %s(%u) is being removed from bubble %u.",
+                mySE->GetName(),
+                mySE->GetID(),
+                mySE->SysBubble()->GetID()
+            );
+        }
+
+        mySE->SysBubble()->Remove(mySE);
+    }
 
     if (currentDistance > m_warpState->accelDist) {
         currentDistance = m_warpState->accelDist;
@@ -1599,10 +1672,18 @@ void DestinyManager::WarpAccel(uint16 sec_into_warp) {
     m_targetDistance -= currentDistance;
     double currentShipSpeed = (3 * currentDistance);
 
-    if (m_warpState->accel)
-        if (is_log_enabled(DESTINY__WARP_TRACE))
-            _log(DESTINY__WARP_TRACE, "Destiny::WarpAccel(): %s(%u) - Warp Accelerating(%us): velocity %.4f m/s with %u m left to go. Current distance %.4f from origin.", \
-                    mySE->GetName(), mySE->GetID(), sec_into_warp, currentShipSpeed, m_targetDistance, currentDistance);
+    if (is_log_enabled(DESTINY__WARP_TRACE) && m_warpState->accel) {
+        _log(
+            DESTINY__WARP_TRACE,
+            "Destiny::WarpAccel(): %s(%u) - Warp Accelerating(%us): velocity %.4f m/s with %.2f m left to go. Current distance %.4f from origin.",
+            mySE->GetName(),
+            mySE->GetID(),
+            sec_into_warp,
+            currentShipSpeed,
+            m_targetDistance,
+            currentDistance
+        );
+    }
 
     WarpUpdate(currentShipSpeed);
 }
@@ -1617,7 +1698,7 @@ void DestinyManager::WarpCruise(uint16 sec_into_warp) {
     }
 
     if (is_log_enabled(DESTINY__WARP_TRACE))
-        _log(DESTINY__WARP_TRACE, "Destiny::WarpCruise(): %s(%u) - Warp Crusing(%us): velocity %.4f m/s. with %u m left to go.", \
+        _log(DESTINY__WARP_TRACE, "Destiny::WarpCruise(): %s(%u) - Warp Cruising(%us): velocity %.4f m/s. with %.2f m left to go.", \
                 mySE->GetName(), mySE->GetID(), sec_into_warp, m_warpState->warpSpeed, m_targetDistance);
 
     WarpUpdate(m_warpState->warpSpeed);
@@ -1630,11 +1711,11 @@ void DestinyManager::WarpDecel(uint16 sec_into_warp) {
      */
     uint8 decelTime = (sec_into_warp - m_warpDecelTime);
     double currentDistance = (m_warpState->total_distance - (exp(-decelTime) * m_warpState->decelDist));
-    m_targetDistance = (int32)(m_warpState->total_distance - currentDistance);
+    m_targetDistance = static_cast<double>(m_warpState->total_distance - currentDistance);
     double currentShipSpeed = (m_warpState->warpSpeed * exp(-decelTime));
 
     if (is_log_enabled(DESTINY__WARP_TRACE))
-        _log(DESTINY__WARP_TRACE, "Destiny::WarpDecel(): %s(%u) - Warp Decelerating(%us/%us): velocity %.4f m/s with %u m left to go.", \
+        _log(DESTINY__WARP_TRACE, "Destiny::WarpDecel(): %s(%u) - Warp Decelerating(%us/%us): velocity %.4f m/s with %.2f m left to go.", \
                 mySE->GetName(), mySE->GetID(), decelTime, sec_into_warp, currentShipSpeed, m_targetDistance);
 
     WarpUpdate(currentShipSpeed);
@@ -1666,7 +1747,7 @@ void DestinyManager::WarpUpdate(double currentShipSpeed) {
 
 void DestinyManager::WarpStop(double currentShipSpeed) {
     if (is_log_enabled(DESTINY__WARP_TRACE)) {
-        _log(DESTINY__WARP_TRACE, "Destiny::WarpStop(): %s(%u) - Warp complete. Exit velocity %.4f m/s with %u m left to go.", \
+        _log(DESTINY__WARP_TRACE, "Destiny::WarpStop(): %s(%u) - Warp complete. Exit velocity %.4f m/s with %.2f m left to go.", \
                 mySE->GetName(), mySE->GetID(), currentShipSpeed, m_targetDistance);
         _log(DESTINY__WARP_TRACE, "Destiny::WarpStop(): %s(%u): Ship currently at %.2f,%.2f,%.2f.", \
                 mySE->GetName(), mySE->GetID(), m_position.x, m_position.y, m_position.z);
@@ -1685,6 +1766,14 @@ void DestinyManager::WarpStop(double currentShipSpeed) {
     if ((mySE->IsNPCSE()) and (mySE->GetNPCSE()->GetAIMgr() != nullptr)) {
         mySE->GetNPCSE()->GetAIMgr()->WarpOutComplete();
     }
+
+    // TODO: when exiting warp, and attempting to warp again shortly after, the
+    // ball mode reaches a weird state where it goes from Warp to a regular
+    // move. Halting the ship after warp completes seems to fix this, but it's
+    // not a good fix, because the client shows that the ship moves a few meters
+    // forward while decelerating - meaning that the client and server are
+    // briefly out of sync because the server thinks the ship is halted.
+    Halt();
 }
 
 //called whenever an entity is going away and can no longer be used as a target
@@ -1788,7 +1877,7 @@ void DestinyManager::BeginMovement() {
     if (m_orbiting == Destiny::Ball::Orbit::None) {
         // reset target distance just in case it changed.
         GVector shipVector(m_position, m_targetPoint);
-        m_targetDistance = (uint32)shipVector.length();
+        m_targetDistance = static_cast<double>(shipVector.length());
         m_orbitRadTic = 0.0f;
         m_maxOrbitSpeedFraction = 1;
     }
@@ -1904,7 +1993,7 @@ void DestinyManager::WarpTo(const GPoint& where, int32 distance/*0*/, bool autoP
     // get warp target point
     GVector warp_distance(m_position, where);
     m_targetDistance = warp_distance.length();
-    m_targetDistance -= m_stopDistance;
+    m_targetDistance -= static_cast<double>(m_stopDistance);
     // change to heading
     warp_distance.normalize();
     // adjust for stop distance from our travel direction
@@ -1914,7 +2003,7 @@ void DestinyManager::WarpTo(const GPoint& where, int32 distance/*0*/, bool autoP
 
     m_targBubble = sBubbleMgr.GetBubble(mySE->SystemMgr(), m_targetPoint);
     if (is_log_enabled(DESTINY__WARP_TRACE))
-        _log(DESTINY__TRACE, "Destiny::WarpTo() - %s(%u) target bubble: %u  m_stopDistance: %i  m_targetDistance: %u",
+        _log(DESTINY__TRACE, "Destiny::WarpTo() - %s(%u) target bubble: %u  m_stopDistance: %i  m_targetDistance: %.2f",
             mySE->GetName(), mySE->GetID(), m_targBubble->GetID(), m_stopDistance, m_targetDistance);
 
     // npcs have no warp restrictions (yet)
@@ -1940,7 +2029,7 @@ void DestinyManager::WarpTo(const GPoint& where, int32 distance/*0*/, bool autoP
         updates.push_back(sfx.Encode());
         SendDestinyUpdate(updates);
         if (is_log_enabled(NPC__MESSAGE))
-            _log(NPC__MESSAGE, "Destiny::WarpTo() NPC %s(%u) to:%u from:%u, m_targetPoint: %.2f,%.2f,%.2f  m_stopDistance: %i  m_targetDistance: %u",\
+            _log(NPC__MESSAGE, "Destiny::WarpTo() NPC %s(%u) to:%u from:%u, m_targetPoint: %.2f,%.2f,%.2f  m_stopDistance: %i  m_targetDistance: %.2f",\
                     mySE->GetName(), mySE->GetID(), m_targBubble->GetID(), mySE->SysBubble()->GetID(), \
                     m_targetPoint.x, m_targetPoint.y, m_targetPoint.z, m_stopDistance, m_targetDistance);
         return;
@@ -1958,7 +2047,7 @@ void DestinyManager::WarpTo(const GPoint& where, int32 distance/*0*/, bool autoP
      */
 
     if (mySE->HasPilot()) {
-        if (m_targetDistance < minWarpDistance) {
+        if (m_targetDistance < static_cast<double>(minWarpDistance)) {
             mySE->GetPilot()->SendErrorMsg("That is too close for your Warp Drive.");
             // warp distance too close.  cancel warp and return
             // we may need to send pos update
@@ -1975,7 +2064,7 @@ void DestinyManager::WarpTo(const GPoint& where, int32 distance/*0*/, bool autoP
          *  Energy to warp = warpCapacitorNeed * mass * au * (1 - warp_drive_operation_skill_level * 0.10)
          */
         float currentShipCap = pClient->GetShip()->GetAttribute(AttrCapacitorCharge).get_float();
-        float capNeeded = m_mass * m_warpCapacitorNeed * (m_targetDistance / ONE_AU_IN_METERS);
+        float capNeeded = m_mass * m_warpCapacitorNeed * (static_cast<double>(m_targetDistance) / static_cast<double>(ONE_AU_IN_METERS));
         capNeeded *= (1.0f - (0.1f *pClient->GetChar()->GetSkillLevel(EvESkill::WarpDriveOperation)));
 
         _log(DESTINY__WARNING, "Warp Cap need for %s(%u) is %.4f", mySE->GetName(), mySE->GetID(), capNeeded);
@@ -1985,13 +2074,13 @@ void DestinyManager::WarpTo(const GPoint& where, int32 distance/*0*/, bool autoP
             // not enough cap.  reset everything based on available cap
             capNeeded = (currentShipCap /m_warpCapacitorNeed) /m_mass;
             if (capNeeded > 1) {
-                m_targetDistance = (uint32)capNeeded * ONE_AU_IN_METERS;
+                m_targetDistance = static_cast<double>(capNeeded) * static_cast<double>(ONE_AU_IN_METERS);
                 GVector warp_direction(m_position, where);
-                GPoint newTarget(m_position + (warp_direction *m_targetDistance));
+                GPoint newTarget(m_position + (warp_direction * m_targetDistance));
 
                 m_targBubble = sBubbleMgr.GetBubble(mySE->SystemMgr(), newTarget);
                 if (is_log_enabled(DESTINY__WARP_TRACE))
-                    _log(DESTINY__TRACE, "Destiny::WarpTo():Update - %s(%u) target bubble: %u  m_stopDistance: %i  m_targetDistance: %u",
+                    _log(DESTINY__TRACE, "Destiny::WarpTo():Update - %s(%u) target bubble: %u  m_stopDistance: %i  m_targetDistance: %.2f",
                         mySE->GetName(), mySE->GetID(), m_targBubble->GetID(), m_stopDistance, m_targetDistance);
             } else {
                 // if not enough cap to do min warp, cancel and return
@@ -2047,21 +2136,31 @@ void DestinyManager::WarpTo(const GPoint& where, int32 distance/*0*/, bool autoP
     SendDestinyUpdate(updates);
     updates.clear();
     //set massive for warp, per client, but self-only
-     SetBallMassive bm;
-        bm.entityID = mySE->GetID();
-        bm.is_massive = false;       // disable client-side bump checks
+    SetBallMassive bm;
+    bm.entityID = mySE->GetID();
+    bm.is_massive = false;       // disable client-side bump checks
     PyTuple *up = bm.Encode();
     SendSingleDestinyUpdate(&up, true);   // consumed
 
-    if (is_log_enabled(DESTINY__WARP_TRACE))
-        _log(DESTINY__WARP_TRACE, "Destiny::WarpTo() toBubble:%u from:%u, m_targetPoint: %.2f,%.2f,%.2f  m_stopDistance: %i  m_targetDistance: %u",
-             m_targBubble->GetID(), mySE->SysBubble()->GetID(), m_targetPoint.x, m_targetPoint.y, m_targetPoint.z, m_stopDistance, m_targetDistance);
+    if (is_log_enabled(DESTINY__WARP_TRACE)) {
+        _log(
+            DESTINY__WARP_TRACE,
+            "Destiny::WarpTo() toBubble:%u from:%u, m_targetPoint: %.2f,%.2f,%.2f  m_stopDistance: %i  m_targetDistance: %.2f",
+            m_targBubble->GetID(),
+            mySE->SysBubble()->GetID(),
+            m_targetPoint.x,
+            m_targetPoint.y,
+            m_targetPoint.z,
+            m_stopDistance,
+            m_targetDistance
+        );
+    }
 }
 
 void DestinyManager::Orbit(SystemEntity *pSE, uint32 distance/*0*/) {
     if ((m_ballMode == Destiny::Ball::Mode::ORBIT)
     and (m_targetEntity.second == pSE)
-    and (m_targetDistance == distance))
+    and (m_targetDistance == static_cast<double>(distance)))
         return;
 
     if (m_orbiting)
@@ -2084,7 +2183,7 @@ void DestinyManager::Orbit(SystemEntity *pSE, uint32 distance/*0*/) {
     m_targetEntity.first = pSE->GetID();
     m_targetEntity.second = pSE;
     m_targetPoint = pSE->GetPosition();
-    m_targetDistance = distance;
+    m_targetDistance = static_cast<double>(distance);
     BeginMovement();
 
     if (is_log_enabled(DESTINY__ORBIT_TRACE))
@@ -2130,7 +2229,7 @@ void DestinyManager::Orbit(SystemEntity *pSE, uint32 distance/*0*/) {
     m_orbitRadTic = EvE::Trig::Pi2 / m_orbitTime;
 
     if (is_log_enabled(DESTINY__ORBIT_TRACE))
-        _log(DESTINY__ORBIT_TRACE, "%s(%u) - Orbit Data - Rc:%.3f, velocity:%.2f, osf:%.2f, targetDistance:%u, followDistance:%u, orbitTime:%.1f, radTic:%.5f", \
+        _log(DESTINY__ORBIT_TRACE, "%s(%u) - Orbit Data - Rc:%.3f, velocity:%.2f, osf:%.2f, targetDistance:%.2f, followDistance:%u, orbitTime:%.1f, radTic:%.5f", \
                 mySE->GetName(), mySE->GetID(), Rc, velocity, m_maxOrbitSpeedFraction, \
                 m_targetDistance, m_followDistance, m_orbitTime, m_orbitRadTic);
 /*  dont really need this here yet.....maybe not at all.
@@ -2544,7 +2643,7 @@ void DestinyManager::MakeMissile(Missile* pMissile) {
     m_targetPoint = GPoint(pTarget->GetPosition());
     m_targetEntity.first = pTarget->GetID();
     m_targetEntity.second = pTarget;
-    m_targetDistance = m_position.distance(m_targetPoint);
+    m_targetDistance = static_cast<double>(m_position.distance(m_targetPoint));
 
     GVector moveVector(m_position, m_targetPoint);
     moveVector.normalize();     //change vector to direction
@@ -2680,7 +2779,7 @@ void DestinyManager::TractorBeamStart(SystemEntity* pShipSE, EvilNumber speed)
 
     m_targetPoint = pShipSE->GetPosition();
     GVector moveVector(m_position, m_targetPoint);
-    m_targetDistance = moveVector.length();
+    m_targetDistance = static_cast<double>(moveVector.length());
     moveVector.normalize();
     m_shipHeading = moveVector;
 

--- a/src/eve-server/system/DestinyManager.cpp
+++ b/src/eve-server/system/DestinyManager.cpp
@@ -3219,7 +3219,9 @@ void DestinyManager::SendSetState() const {
         );
     }
 
-    // if the player is not warping, tell the client they're not warping
+    // if the player is not warping, tell the client they're not warping.
+    // As of 2024-10-03, this doesn't always work and there are still issues
+    // with the client sometimes not starting a warp sequence.
     std::vector<PyTuple*> updates;
     OnSpecialFX10 sfx;
     sfx.guid = "effects.Warping";
@@ -3242,9 +3244,8 @@ void DestinyManager::SendSetState() const {
     ss.ego = mySE->GetID();
 
     if (mySE->SysBubble() == nullptr) {
-        // returning here preemptively avoids a segfault, but isn't a good
-        // situation. seems like it happens during warp, just after the player
-        // has been removed from a bubble.
+        // returning here preemptively avoids a segfault (good), but isn't a
+        // good situation to encounter.
         sLog.Error(
             "DestinyManager::SendSetState()",
             "Destiny::SendSetState() the player isn't in a system bubble! Aborting attempt to send state."

--- a/src/eve-server/system/DestinyManager.h
+++ b/src/eve-server/system/DestinyManager.h
@@ -296,7 +296,7 @@ protected:
     float m_maxOrbitSpeedFraction;      //fuzzy logic - ship's max speed based on orbit data
 
     uint32 m_followDistance;            //in m
-    uint32 m_targetDistance;            //in m
+    double m_targetDistance;            //in m
     double m_moveTime;                  //in ms       - time when speed change started.  used to calculate m_timeFraction
     double m_callTime;                  //in ms       - time client call was processed.  this is to coordinate tic calculations
 

--- a/src/eve-server/system/SystemBubble.cpp
+++ b/src/eve-server/system/SystemBubble.cpp
@@ -193,43 +193,78 @@ void SystemBubble::ProcessWander(std::vector<SystemEntity*> &wanderers) {
         ResetBubbleRatSpawn();
 }
 
-void SystemBubble::Add(SystemEntity* pSE)
-{
+void SystemBubble::Add(SystemEntity* pSE) {
     //if they are already in this bubble, do not continue.
     if (m_entities.find(pSE->GetID()) != m_entities.end()) {
-        _log(DESTINY__BUBBLE_TRACE, "SystemBubble::Add() - Tried to add Static Entity %u to bubble %u, but it is already in here.",\
-             pSE->GetID(), m_bubbleID);
+        _log(
+            DESTINY__BUBBLE_TRACE,
+            "SystemBubble::Add() - Tried to add Static Entity %u to bubble %u, but it is already in here.",
+            pSE->GetID(),
+            m_bubbleID
+        );
+
         return;
     }
 
     pSE->m_bubble = this;
-    // global entities also in SystemMgr's static list.  this is used for SystemBubble->IsEmpty() deletion check
+
+    // global entities also in SystemMgr's static list.  this is used for
+    // SystemBubble->IsEmpty() deletion check
     if (pSE->IsStaticEntity() or pSE->isGlobal()) {
-        _log(DESTINY__BUBBLE_TRACE, "SystemBubble::Add() - Entity %s(%u) is static or global or both.", pSE->GetName(), pSE->GetID() );
-        // all static and global entities (stations, gates, asteroid fields, cyno fields, etc) are put into bubble's staticEntity map
+        _log(
+            DESTINY__BUBBLE_TRACE,
+            "SystemBubble::Add() - Entity %s(%u) is static or global or both.",
+            pSE->GetName(),
+            pSE->GetID()
+        );
+
+        // all static and global entities (stations, gates, asteroid fields,
+        // cyno fields, etc) are put into bubble's staticEntity map
         m_entities[pSE->GetID()] = pSE;
+
         return;
     }
 
     //if they are already in this bubble, do not continue.
     if (m_dynamicEntities.find(pSE->GetID()) != m_dynamicEntities.end()) {
-        _log(DESTINY__BUBBLE_TRACE, "SystemBubble::Add() - Tried to add Dynamic Entity %u to bubble %u, but it is already in here.",\
-                pSE->GetID(), m_bubbleID);
+        _log(
+            DESTINY__BUBBLE_TRACE,
+            "SystemBubble::Add() - Tried to add Dynamic Entity %u to bubble %u, but it is already in here.",
+            pSE->GetID(),
+            m_bubbleID
+        );
+
         return;
     }
 
-    _log(DESTINY__BUBBLE_TRACE, "SystemBubble::Add() - Adding entity %u to bubble %u.  Dist to center: %.2f", \
-            pSE->GetID(), m_bubbleID, m_center.distance(pSE->GetPosition()));
+    _log(
+        DESTINY__BUBBLE_TRACE,
+        "SystemBubble::Add() - Adding entity %u to bubble %u.  Dist to center: %.2f",
+        pSE->GetID(),
+        m_bubbleID,
+        m_center.distance(pSE->GetPosition())
+    );
 
     if (is_log_enabled(DESTINY__BUBBLE_DEBUG)) {
         GPoint startPoint( pSE->GetPosition() );
         GVector direction(startPoint, NULL_ORIGIN);
+
         double rangeToStar = direction.length();
+
         rangeToStar /= ONE_AU_IN_METERS;
-        _log(DESTINY__BUBBLE_DEBUG, "SystemBubble::Add() - Distance to Star %.2f AU.  %u/%u Entities in bubble %u",\
-                rangeToStar, m_entities.size(), m_dynamicEntities.size(), m_bubbleID);
-        //if (sConfig.debug.StackTrace)
+
+        _log(
+            DESTINY__BUBBLE_DEBUG,
+            "SystemBubble::Add() - Distance to Star %.2f AU.  %u/%u Entities in bubble %u",
+            rangeToStar,
+            m_entities.size(),
+            m_dynamicEntities.size(),
+            m_bubbleID
+        );
+
+        // if (sConfig.debug.StackTrace) {
         //    EvE::traceStack();
+        // }
     }
 
     if (pSE->HasPilot()) {
@@ -237,18 +272,27 @@ void SystemBubble::Add(SystemEntity* pSE)
         if (m_belt) {
             // check for roids and load/spawn as needed.
             m_system->GetBeltMgr()->CheckSpawn(m_bubbleID);
-            if (sConfig.npc.RoamingSpawns)
-                if (!m_spawnTimer.Enabled())
+
+            if (sConfig.npc.RoamingSpawns) {
+                if (!m_spawnTimer.Enabled()) {
                     SetSpawnTimer(true);
+                }
+            }
         }
-        if (m_gate and sConfig.npc.StaticSpawns)
-            if (!m_spawnTimer.Enabled())
+
+        if (m_gate and sConfig.npc.StaticSpawns) {
+            if (!m_spawnTimer.Enabled()) {
                 SetSpawnTimer(false);
+            }
+        }
 
         Client* pClient(pSE->GetPilot());
+
         SendAddBalls( pSE );
-        if (!m_players.empty())
+
+        if (!m_players.empty()) {
             AddBallExclusive(pSE);  // adds new player to all players in bubble, if any
+        }
 
         m_players[pClient->GetCharacterID()] = pClient;   //add to bubble's player list
     } else {
@@ -341,8 +385,7 @@ void SystemBubble::SetBelt(InventoryItemRef itemRef)
         m_ice = true;
 }
 
-void SystemBubble::SetGate(uint32 gateID)
-{
+void SystemBubble::SetGate(uint32 gateID) {
     m_gate = true;
     sBubbleMgr.AddSpawnID(m_bubbleID, gateID);
 }
@@ -795,45 +838,52 @@ void SystemBubble::SyncPos() {
     for (auto player : m_players)
         for (auto dse : m_dynamicEntities) {
             SetBallPosition du;
-                du.entityID = dse.first;
-                du.x = dse.second->GetPosition().x;
-                du.y = dse.second->GetPosition().y;
-                du.z = dse.second->GetPosition().z;
+
+            du.entityID = dse.first;
+            du.x = dse.second->GetPosition().x;
+            du.y = dse.second->GetPosition().y;
+            du.z = dse.second->GetPosition().z;
+
             PyTuple* up = du.Encode();
+
             player.second->GetShipSE()->DestinyMgr()->SendSingleDestinyUpdate(&up);
         }
 }
 
-void SystemBubble::CmdDropLoot()
-{
+void SystemBubble::CmdDropLoot() {
     for (auto dse : m_dynamicEntities) {
-        if (dse.second->IsNPCSE())
+        if (dse.second->IsNPCSE()) {
             dse.second->GetNPCSE()->CmdDropLoot();
+        }
     }
 }
 
 
-void SystemBubble::RemoveMarkers()
-{
-    if (m_hasMarkers)
+void SystemBubble::RemoveMarkers() {
+    if (m_hasMarkers) {
         for (auto cur : m_markers) {
             m_system->RemoveEntity(cur.second);
             cur.second->Delete(); // delete marker cans here
             SafeDelete(cur.second);
         }
+    }
+
     m_markers.clear();
     m_centerSE = nullptr;
     m_hasMarkers = false;
 }
 
 
-void SystemBubble::MarkCenter()
-{
+void SystemBubble::MarkCenter() {
     // we are not creating markers on system boot.
-    if (!m_system->IsLoaded())
+    if (!m_system->IsLoaded()) {
         return;
-    if (m_hasMarkers)
+    }
+
+    if (m_hasMarkers) {
         return;
+    }
+
     // create jetcan to mark bubble center
     std::string str = "Center Marker for Bubble #", desc = "Bubble Center"; //std::to_string(m_bubbleID);
     str += std::to_string(m_bubbleID);

--- a/src/eve-server/system/SystemEntity.h
+++ b/src/eve-server/system/SystemEntity.h
@@ -216,7 +216,7 @@ public:
     virtual bool                IsDungeonEditSE()       { return false; }
 
     /* generic functions handled here */
-    EVEServiceManager&               GetServices()      { return m_services; }
+    EVEServiceManager&          GetServices()           { return m_services; }
     SystemBubble*               SysBubble()             { return m_bubble; }
     SystemManager*              SystemMgr()             { return m_system; }
     TargetManager*              TargetMgr()             { return m_targMgr; }


### PR DESCRIPTION
If you enable a notification that shows when the server thinks you've stopped warping, you'll see that it happens very quickly after starting warp. I suspect this is because destiny's `m_targetDistance` (used in warp calculations) is currently a `uint32` value, which cannot exceed 4 billion meters. 1 AU is 150 billion meters, so I suspect the data type is overflowing and we're seeing odd behavior with destiny that causes the server to think warp is finishing way too early.

This PR changes the data type from `uint32` to `double`. It seems like this stabilizes the calculations quite a bit, but it still isn't perfect.

The other significant change in this PR is that during warp cruise, a sysbubble is allowed to be created on every server tick. This allows the server to correctly act on its assumptions that the player is always in a sysbubble when in space. Previously it was not in a sysbubble during warp cruise. A side effect of this is that the player is repeatedly entering and exiting sysbubbles during every second of warp, but I don't see any other way to implement it currently.

Also included in this PR are some other changes:

- call `Halt()` after warp stop occurs, for slightly better stability (this requires further investigation)
  - symptom: warping from A to B and then B to C immediately after can sometimes cause the ball mode to go from `WARP` to `GOTO` after the next tick (instead of staying on `WARP` for as many ticks as it takes to finish the whole warp). Halting after warp seems to prevent this. This is a bandaid fix, because without it, warping anywhere breaks in a very annoying way (the server just thinks you're moving in the direction of warp forever and it never actually warps you, but the client does).
- use `abs()` for distance calculation when determining if the warp distance is less than the warp speed of the ship
- code cleanup in a few spots
- static casting to double in a few more places to make data types match up better (in an effort to minimize precision loss)
- gracefully returns from `/setstate` (destiny sendstate call specifically) early if the player is in a `nullptr` sysbubble to avoid a segfault

---

I'm leaving this pull request in draft state for now so that I can test it out for a little while. I don't anticipate the code changing _too_ much more though, so feel free to add any review comments/thoughts.

## Summary by Sourcery

Change m_targetDistance from uint32 to double to fix warp calculation overflow issues, enhance warp stability with additional logic, and refactor code for improved precision and readability.

Bug Fixes:
- Fix warp calculation overflow by changing m_targetDistance from uint32 to double, addressing issues with premature warp stop notifications.

Enhancements:
- Improve warp stability by calling Halt() after warp stop to prevent incorrect ball mode transitions.
- Use abs() for distance calculations to ensure correct warp distance comparisons.
- Perform static casting to double in various places to improve data type consistency and minimize precision loss.
- Refactor logging statements for better readability and consistency across the codebase.