### PR TITLE
Prevent segfaults in ProcessWander when docking after flying around

### DIFF
--- a/src/eve-server/system/BubbleManager.cpp
+++ b/src/eve-server/system/BubbleManager.cpp
@@ -112,8 +112,9 @@ void BubbleManager::Process() {
         }
     }
 
-    if (m_emptyTimer.Check())   //60s
+    if (m_emptyTimer.Check()) {  //60s
         RemoveEmpty();
+    }
 
     if (sConfig.debug.UseProfiling)
         sProfiler.AddTime(Profile::bubbles, GetTimeUSeconds() - profileStartTime);
@@ -196,10 +197,37 @@ void BubbleManager::NewBubbleCenter(GVector shipVelocity, GPoint &newCenter) {
 
 void BubbleManager::Remove(SystemEntity *ent) {
     // suns, planets and moons arent in bubbles
-    //if (ent->IsStaticEntity())
+    // if (ent->IsStaticEntity())
     //    return;
     if (ent->SysBubble() != nullptr) {
-        _log(DESTINY__BUBBLE_TRACE, "BubbleManager::Remove(): Entity %s(%u) being removed from Bubble %u", ent->GetName(), ent->GetID(), ent->SysBubble()->GetID() );
+        _log(
+            DESTINY__BUBBLE_DEBUG,
+            "BubbleManager::Remove(): Entity %s(%u) being removed from Bubble %u",
+            ent->GetName(),
+            ent->GetID(),
+            ent->SysBubble()->GetID()
+        );
+
+        // iterate through all other bubbles and determine if the entity is
+        // in them.
+        std::list<SystemBubble *>::iterator itr = m_bubbles.begin();
+        while (itr != m_bubbles.end()) {
+            if (*itr == nullptr) {
+                continue;
+            }
+
+            _log(
+                DESTINY__BUBBLE_DEBUG,
+                "BubbleManager::Remove(): Entity %s(%u) being untracked from Bubble %u",
+                ent->GetName(),
+                ent->GetID(),
+                ent->SysBubble()->GetID()
+            );
+
+            (*itr)->Untrack(ent);
+            ++itr;
+        }
+
         ent->SysBubble()->Remove(ent);
     }
 }

--- a/src/eve-server/system/SystemBubble.cpp
+++ b/src/eve-server/system/SystemBubble.cpp
@@ -436,7 +436,6 @@ void SystemBubble::Untrack(SystemEntity *pSE) {
     if (pSE->IsDroneSE()) {
         m_drones.erase(pseId);
     }
-
 }
 
 /**

--- a/src/eve-server/system/SystemBubble.h
+++ b/src/eve-server/system/SystemBubble.h
@@ -97,6 +97,14 @@ public:
     void PrintEntityList();
 
     void Add(SystemEntity* pSE);
+    /**
+     * Provides a means to remove an entity from the SystemBubble's map of
+     * tracked dynamic entities without unsetting the SystemEntity's bubble.
+     *
+     * See `SystemBubble::Remove` for calling this and also unsetting the
+     * `SystemEntity`'s bubble.
+     */
+    void Untrack(SystemEntity* pSE);
     void Remove(SystemEntity* pSE);
     void ProcessWander(std::vector< SystemEntity* >& wanderers);
 


### PR DESCRIPTION
This PR prevents segfaults in `SystemBubble::ProcessWander` by untracking soon-to-be-destroyed (i.e. docking) SystemEntities from _every_ bubble they were in recently, not just the bubble they currently reside within.

---

**Explanation**

After implementing the fixes in #295, a new bug was rearing its head. Every time I would dock after warping somewhere, the server would segfault within about 1 minute.

Turns out that `SystemBubble::ProcessWander` was what was triggering the segfault. It gets called every minute to clean up entities that are no longer present in each bubble.

`ProcessWander` iterates over a map, with each key/value pair containing an entity ID and the pointer to the underlying `SystemEntity`. It iterates over each entry in the map, attempting to ascertain whether or not the entity should be considered a "wanderer". Such examples of non-wanderers include certain celestials, wrecks, or wormholes, for example.

A player's ship is considered a wanderer frequently, because each tick during warp (introduced in #295) generates a new Bubble. In order to clean up the bubbles, `ProcessWander` needs to first determine who is still within it and remove the entities until each bubble has no entities in its map, which allows the bubble to be deleted later.

The segfault thus occurs when the player docks, but has also recently warped. When the player docks, `BubbleManager::Remove` is called on the player's `SystemEntity`, but unfortunately, **it only removes the entity from its current bubble**.

The player's `SystemEntity` pointer is safely deleted as part of this process, but the reason for the segfault is that **all of the other bubbles that the ship recently warped through still contain pointers in their mappings of entities _they each think they still have_ within their own bubble**.

---

**Resolution**

The `BubbleManager::Remove` method has been updated to iterate over every single bubble, removing the `SystemEntity` before proceeding to remove its final Bubble. This is facilitated via the new `SystemBubble::Untrack` method that is identical to `SystemBubble::Remove`, but it omits the final call to set the `SystemEntity`'s `m_bubble` pointer to a `nullptr`.

---

**Testing**

So far the fix seems stable. I'm able to fly around to various spots, dock, undock, etc.

---

**Other changes**

Any other changes are only either autoformatter changes or more logging statements.

## Summary by Sourcery

Prevent segfaults in SystemBubble::ProcessWander by untracking SystemEntities from all bubbles they were recently in. Introduce a new method, SystemBubble::Untrack, to facilitate this process without unsetting the SystemEntity's bubble. Enhance logging for better traceability.

Bug Fixes:
- Prevent segfaults in SystemBubble::ProcessWander by ensuring SystemEntities are untracked from all bubbles they were recently in, not just the current one.

Enhancements:
- Add logging statements to SystemBubble::ProcessWander for better traceability and debugging.