### PR TITLE
Fixed the issue of quickly closing the EVEMU main program by pressing CTRL+C in Linux system.

### DIFF
--- a/src/eve-server/eve-server.cpp
+++ b/src/eve-server/eve-server.cpp
@@ -25,6 +25,9 @@
  */
 
 #include "eve-server.h"
+
+// Global TCP server instance for cleanup access
+EVETCPServer tcps;
 // version
 #include "../eve-common/EVEVersion.h"
 
@@ -583,7 +586,6 @@ int main( int argc, char* argv[] )
     sAllocators.tickAllocator.Init(Allocators::TICK_ALLOCATOR_SIZE, "TickAllocator");
 
     /* Start up the TCP server */
-    EVETCPServer tcps;
     char errbuf[ TCPCONN_ERRBUF_SIZE ];
     sLog.Green( "       ServerInit", "Starting TCP Server");
     if (tcps.Open(sConfig.net.port, errbuf)) {
@@ -1039,7 +1041,7 @@ static void CleanUp() {
     if (!sConsole.IsDbError())
         ServiceDB::SetServerOnlineStatus(false);
     /* stop TCP listener */
-    //tcps.Close();
+    tcps.Close();
     sLog.Warning("   ServerShutdown", "TCP listener stopped." );
     /* stop Image Server */
     sImageServer.Stop();

--- a/src/eve-server/eve-server.cpp
+++ b/src/eve-server/eve-server.cpp
@@ -916,9 +916,9 @@ int main( int argc, char* argv[] )
         m_run = sConsole.Process();
 
         /* do the stuff for thread sleeping */
-        start = GetTickCount() - start;
-        if (m_sleepTime > start)
-            std::this_thread::sleep_for(std::chrono::milliseconds(start));
+        uint32 elapsed = GetTickCount() - start;
+        uint32 sleepTime = m_sleepTime > elapsed ? m_sleepTime - elapsed : 0;
+        std::this_thread::sleep_for(std::chrono::milliseconds(sleepTime));
     }
 
     /*
@@ -1030,9 +1030,8 @@ static void CatchSignal( int sig_num )
     sLog.Error( "    Signal System", "Caught signal: %d", sig_num );
     if (sConfig.debug.StackTrace)
         EvE::traceStack();
-    //SafeSave();
+    sItemFactory.SaveItems();
     m_run = false;
-    //CleanUp();
 }
 
 static void CleanUp() {


### PR DESCRIPTION
Fixed the issue of quickly closing the EVEMU main program by pressing CTRL+C in Linux system.

## Summary by Sourcery

Implement graceful shutdown on Ctrl+C for the EVEMU server by relocating the TCP server instance, updating the signal handler to save items and close the listener, and fixing the main loop’s sleep calculation.

Bug Fixes:
- Prevent immediate termination on Ctrl+C by using a global TCP server instance for cleanup
- Save items in the signal handler to avoid data loss on exit
- Close the TCP listener during shutdown to enable graceful server termination

Enhancements:
- Refactor main loop sleep calculation to compute non-negative sleep durations