### PR TITLE
19:49:45 [ThreadInfo] CreateThread() - Creating new threadID 0x0 19:49:45 E     Signal System: Caught signal: 6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@
 ###############
 # We need a target-specific property INCLUDE_DIRECTORIES which
 # is part of CMake 2.8.8 and later.
-CMAKE_MINIMUM_REQUIRED( VERSION 2.8.8 FATAL_ERROR )
+CMAKE_MINIMUM_REQUIRED( VERSION 3.5.0 FATAL_ERROR )
 
 PROJECT( "evemu" )
 SET( PROJECT_DESCRIPTION_SUMMARY "A server emulator for EVE Online" )

--- a/src/eve-common/auth/BinAsciiModule.h
+++ b/src/eve-common/auth/BinAsciiModule.h
@@ -23,6 +23,8 @@
     Author:        Captnoord
 */
 
+#include <eve-compat.h>
+#include <string.h>
 #ifndef BIN_ASCII_MODULE_H
 #define BIN_ASCII_MODULE_H
 

--- a/src/eve-core/utils/Buffer.h
+++ b/src/eve-core/utils/Buffer.h
@@ -867,6 +867,12 @@ protected:
      */
     void _Reallocate( size_type requiredSize )
     {
+        if (requiredSize == 0) {
+            SafeFree(mBuffer);
+            mCapacity = 0;
+            mSize = 0;
+            return;
+        }
         // calculate new capacity for required size
         size_type newCapacity = _CalcBufferCapacity( capacity(), requiredSize );
         // make sure new capacity is bigger than required size

--- a/src/eve-core/utils/Buffer.h
+++ b/src/eve-core/utils/Buffer.h
@@ -51,22 +51,18 @@ public:
      */
     template< typename T >
     class const_iterator
-    : public std::iterator< std::random_access_iterator_tag, T >
     {
-        /// Typedef for our base due to readibility.
-        typedef std::iterator< std::random_access_iterator_tag, T > _Base;
-
     public:
         /// Typedef for iterator category.
-        typedef typename _Base::iterator_category iterator_category;
+        typedef std::random_access_iterator_tag iterator_category;
         /// Typedef for value type.
-        typedef typename _Base::value_type        value_type;
+        typedef T                              value_type;
         /// Typedef for difference type.
-        typedef typename _Base::difference_type   difference_type;
+        typedef std::ptrdiff_t                 difference_type;
         /// Typedef for pointer.
-        typedef typename _Base::pointer           pointer;
+        typedef T*                             pointer;
         /// Typedef for reference.
-        typedef typename _Base::reference         reference;
+        typedef T&                             reference;
 
         /// Typedef for const pointer.
         typedef const T* const_pointer;


### PR DESCRIPTION
Fixed _Reallocate method:
Added check on realloc return value
If reallocation fails, log error and keep old buffer
Enhanced AssignAt and AssignSeqAt methods:
Added null pointer check
Added additional bounds check
Log error and return safely when problem detected
Fixed operator[] and Get methods:
Added null pointer check
Added bounds check
Return safe default value instead of crashing when problem detected
Fixed begin and end methods:
Added null pointer check
Ensure safe iterators are returned when buffer is invalid
Added necessary header files:
Included log/logsys.h to support error logging

## Summary by Sourcery

Improve robustness of the Buffer utility by adding null pointer and bounds checks, returning safe defaults, and logging errors for invalid operations; handle realloc failures gracefully; bump CMake version and add necessary header includes for logging and compatibility.

Bug Fixes:
- Prevent crashes in Buffer by checking for null mBuffer and out-of-range indices before access and write operations.
- Handle realloc failures in Buffer::_Reallocate by logging an error and retaining the original buffer.

Enhancements:
- Add detailed error logging in Buffer methods (begin, end, Get, operator[], AssignAt, AssignSeqAt) and return static dummy values or safe iterators on error.

Build:
- Increase CMake minimum required version to 3.5.0.

Chores:
- Include log/logsys.h in Buffer.h and add eve-compat.h and string.h in BinAsciiModule.h for logging support and compatibility.