### PR TITLE
Fixed the issue where you had to warp to the collapse point every time you logged in in space. 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@
 ###############
 # We need a target-specific property INCLUDE_DIRECTORIES which
 # is part of CMake 2.8.8 and later.
-CMAKE_MINIMUM_REQUIRED( VERSION 2.8.8 FATAL_ERROR )
+CMAKE_MINIMUM_REQUIRED( VERSION 3.5.0 FATAL_ERROR )
 
 PROJECT( "evemu" )
 SET( PROJECT_DESCRIPTION_SUMMARY "A server emulator for EVE Online" )

--- a/src/eve-common/CMakeLists.txt
+++ b/src/eve-common/CMakeLists.txt
@@ -109,11 +109,11 @@ SET( packets_INCLUDE
      "${TARGET_PACKETS_DIR}/packets/Planet.h"
      "${TARGET_PACKETS_DIR}/packets/Repair.h"
      "${TARGET_PACKETS_DIR}/packets/Scan.h"
-     #"${TARGET_PACKETS_DIR}/packets/Salvage.h"
      "${TARGET_PACKETS_DIR}/packets/Sovereignty.h"
      "${TARGET_PACKETS_DIR}/packets/Trade.h"
      "${TARGET_PACKETS_DIR}/packets/Tutorial.h"
-     "${TARGET_PACKETS_DIR}/packets/Wallet.h" )
+     "${TARGET_PACKETS_DIR}/packets/Wallet.h"
+     "${TARGET_PACKETS_DIR}/packets/Crimewatch.h" )
 SET( packets_SOURCE
      "${TARGET_PACKETS_DIR}/packets/AccountPkts.cpp"
      "${TARGET_PACKETS_DIR}/packets/Bookmarks.cpp"
@@ -140,7 +140,8 @@ SET( packets_SOURCE
      "${TARGET_PACKETS_DIR}/packets/Sovereignty.cpp"
      "${TARGET_PACKETS_DIR}/packets/Trade.cpp"
      "${TARGET_PACKETS_DIR}/packets/Tutorial.cpp"
-     "${TARGET_PACKETS_DIR}/packets/Wallet.cpp" )
+     "${TARGET_PACKETS_DIR}/packets/Wallet.cpp"
+     "${TARGET_PACKETS_DIR}/packets/Crimewatch.cpp" )
 SET( packets_XMLP
      "${TARGET_SOURCE_DIR}/packets/AccountPkts.xmlp"
      "${TARGET_SOURCE_DIR}/packets/Bookmarks.xmlp"
@@ -167,7 +168,8 @@ SET( packets_XMLP
      "${TARGET_SOURCE_DIR}/packets/Sovereignty.xmlp"
      "${TARGET_SOURCE_DIR}/packets/Trade.xmlp"
      "${TARGET_SOURCE_DIR}/packets/Tutorial.xmlp"
-     "${TARGET_SOURCE_DIR}/packets/Wallet.xmlp" )
+     "${TARGET_SOURCE_DIR}/packets/Wallet.xmlp"
+     "${TARGET_SOURCE_DIR}/packets/Crimewatch.xmlp" )
 
 SET( python_INCLUDE
      "${TARGET_INCLUDE_DIR}/python/PyDumpVisitor.h"

--- a/src/eve-common/EVEVersion.h
+++ b/src/eve-common/EVEVersion.h
@@ -37,12 +37,12 @@
 // Client version info
 // supported client is Crucible v1.6.5 build 360229
 // this is ALL CPP information needed by the client
-static const double EVEVersionNumber = 7.31;
-static const uint16 MachoNetVersion = 320;
-static const int32 EVEBuildVersion = 360229;
-static const char* const EVEProjectRegion = "ccp";
-static const char* const EVEProjectVersion = "EVE-EVE-TRANQUILITY@ccp";
-static const char* const EVEProjectCodename = "EVE-EVE-TRANQUILITY";
+static const double EVEVersionNumber = 14.08;
+static const uint16 MachoNetVersion = 425;
+static const int32 EVEBuildVersion = 1082510;
+static const char* const EVEProjectRegion = "optic";
+static const char* const EVEProjectVersion = "EVE-SERENITY@optic";
+static const char* const EVEProjectCodename = "EVE-SERENITY";
 
 static const int32 EVEBirthday = 170472;
 

--- a/src/eve-common/EVE_Missions.h
+++ b/src/eve-common/EVE_Missions.h
@@ -41,7 +41,7 @@ struct MissionOffer {
     uint32 offerID;
     uint32 agentID;
     uint32 briefingID;          // this is mission briefing messageID for locale
-    //uint32 contentID;           // on live, this is specific char data for mission keywords.  we're not using it
+    uint32 contentID;           // on live, this is specific char data for mission keywords.  we're not using it
     uint32 characterID;
     uint32 rewardISK;
     uint32 bonusISK;

--- a/src/eve-common/network/EVEPktDispatch.cpp
+++ b/src/eve-common/network/EVEPktDispatch.cpp
@@ -68,7 +68,7 @@ bool EVEPacketDispatcher::DispatchPacket(PyPacket* packet)
         }
         case CALL_REQ: {
             //check the string part, just for good measure
-            if (packet->type_string != "macho.CallReq") {
+            if (packet->type_string != "macho.CallReq" && packet->type_string != "carbon.common.script.net.machoNetPacket.CallReq") {
                 sLog.Error("EVEPacketDispatcher","Received CALL_REQ with invalid type string '%s'", packet->type_string.c_str());
                 return false;
             }
@@ -83,7 +83,7 @@ bool EVEPacketDispatcher::DispatchPacket(PyPacket* packet)
         }
         case CALL_RSP: {
             //check the string part, just for good measure
-            if (packet->type_string != "macho.CallRsp") {
+            if (packet->type_string != "macho.CallRsp" && packet->type_string != "carbon.common.script.net.machoNetPacket.CallRsp") {
                 sLog.Error("EVEPacketDispatcher","Received CALL_RSP with invalid type string '%s'", packet->type_string.c_str());
                 return false;
             }

--- a/src/eve-common/network/EVEPktDispatch.cpp
+++ b/src/eve-common/network/EVEPktDispatch.cpp
@@ -133,7 +133,7 @@ bool EVEPacketDispatcher::DispatchPacket(PyPacket* packet)
         }
         case PING_REQ: {
             //check the string part, just for good measure
-            if (packet->type_string != "macho.PingReq") {
+            if (packet->type_string != "macho.PingReq" && packet->type_string != "carbon.common.script.net.machoNetPacket.PingReq") {
                 sLog.Error("EVEPacketDispatcher","Received PING_REQ with invalid type string '%s'", packet->type_string.c_str());
                 return false;
             }
@@ -195,8 +195,8 @@ bool EVEPacketDispatcher::Handle_SessionChange(PyPacket* packet, SessionChangeNo
 
 bool EVEPacketDispatcher::Handle_PingReq(PyPacket* packet)
 {
-    sLog.Error("EVEPacketDispatcher","Unhandled Ping Request.");
-    return false;
+    sLog.Blue("EVEPacketDispatcher","Ping Request received.");
+    return true;
 }
 bool EVEPacketDispatcher::Handle_PingRsp(PyPacket* packet)
 {

--- a/src/eve-common/packets/Crimewatch.xmlp
+++ b/src/eve-common/packets/Crimewatch.xmlp
@@ -1,0 +1,54 @@
+<elements>
+
+  <elementDef name="Crimewatch_BindArgs">
+    <tupleInline>
+      <int name="locationID" />
+      <int name="groupID" />
+    </tupleInline>
+  </elementDef>
+
+  <elementDef name="Crimewatch_Engagement">
+    <dictInline>
+      <dictInlineEntry key="engagementID">
+        <int name="engagementID" />
+      </dictInlineEntry>
+      <dictInlineEntry key="issuerID">
+        <int name="issuerID" />
+      </dictInlineEntry>
+      <dictInlineEntry key="charID">
+        <int name="charID" />
+      </dictInlineEntry>
+      <dictInlineEntry key="duration">
+        <int name="duration" />
+      </dictInlineEntry>
+      <dictInlineEntry key="expiredTime">
+        <int name="expiredTime" />
+      </dictInlineEntry>
+      <dictInlineEntry key="status">
+        <int name="status" />
+      </dictInlineEntry>
+      <dictInlineEntry key="typeID">
+        <int name="typeID" />
+      </dictInlineEntry>
+      <dictInlineEntry key="level">
+        <int name="level" />
+      </dictInlineEntry>
+      <dictInlineEntry key="factionID">
+        <int name="factionID" />
+      </dictInlineEntry>
+      <dictInlineEntry key="weaponModifier">
+        <int name="weaponModifier" />
+      </dictInlineEntry>
+      <dictInlineEntry key="shieldModifier">
+        <int name="shieldModifier" />
+      </dictInlineEntry>
+      <dictInlineEntry key="armorModifier">
+        <int name="armorModifier" />
+      </dictInlineEntry>
+      <dictInlineEntry key="hpModifier">
+        <int name="hpModifier" />
+      </dictInlineEntry>
+    </dictInline>
+  </elementDef>
+
+</elements>

--- a/src/eve-common/packets/Crypto.xmlp
+++ b/src/eve-common/packets/Crypto.xmlp
@@ -111,6 +111,9 @@
           <dictInlineEntry key="user_affiliateid">
               <int name="user_affiliateid" />
           </dictInlineEntry>
+          <dictInlineEntry key="user_sso_token">
+              <wstring name="user_sso_token" safe="true" none_marker="" />
+          </dictInlineEntry>
         </dictInline>
     </tupleInline>
   </elementDef>

--- a/src/eve-common/packets/Inventory.xmlp
+++ b/src/eve-common/packets/Inventory.xmlp
@@ -64,6 +64,9 @@
       <dictInlineEntry key="time">
         <long name="time" />
       </dictInlineEntry>
+      <dictInlineEntry key="wallclockTime">
+        <long name="wallclockTime" />
+      </dictInlineEntry>
     </dictInline>
   </elementDef>
 

--- a/src/eve-common/python/PyPacket.cpp
+++ b/src/eve-common/python/PyPacket.cpp
@@ -65,7 +65,9 @@ type(__Fake_Invalid_Type),
 userid(0),
 payload(nullptr),
 named_payload(nullptr),
-contextKey(nullptr)
+contextKey(nullptr),
+applicationID(),
+languageID()
 {
 }
 
@@ -73,6 +75,7 @@ PyPacket::~PyPacket()
 {
     PySafeDecRef(payload);
     PySafeDecRef(named_payload);
+    PySafeDecRef(contextKey);
 }
 
 PyPacket *PyPacket::Clone() const
@@ -88,6 +91,12 @@ PyPacket *PyPacket::Clone() const
         res->named_payload = nullptr;
     else
         res->named_payload = named_payload->Clone()->AsDict();
+    if (contextKey == nullptr)
+        res->contextKey = nullptr;
+    else
+        res->contextKey = contextKey->Clone();
+    res->applicationID = applicationID;
+    res->languageID = languageID;
     return res;
 }
 
@@ -161,8 +170,8 @@ bool PyPacket::Decode(PyRep **in_packet)
         return false;
     }
 
-    if (tuple->items.size() != 7) {
-        codelog(NET__PACKET_ERROR, "PyPacket::Decode() - packet body does not contain a tuple of length 7 (is %u)", tuple->items.size());
+    if (tuple->items.size() != 7 && tuple->items.size() != 9) {
+        codelog(NET__PACKET_ERROR, "PyPacket::Decode() - packet body does not contain a tuple of length 7 or 9 (is %u)", tuple->items.size());
         PyDecRef(packet);
         return false;
     }
@@ -232,12 +241,50 @@ bool PyPacket::Decode(PyRep **in_packet)
         return false;
     }
 
+    // contextKey, gives the client extra information on what exactly is going on
+    // this is PyNone almost 100% of the time and seems to be used in the node<->proxy communication
+    if (tuple->items.size() == 9) {
+        if (tuple->items[6]->IsNone()) {
+            contextKey = nullptr;
+        } else {
+            contextKey = tuple->items[6];
+            PyIncRef(contextKey);
+        }
+
+        // applicationID, used for routing
+        if (tuple->items[7]->IsNone()) {
+            applicationID = "";
+        } else if (tuple->items[7]->IsString()) {
+            applicationID = tuple->items[7]->AsString()->content();
+        } else {
+            codelog(NET__PACKET_ERROR, "PyPacket::Decode() - Eighth main tuple element is neither string or none.");
+            PyDecRef(packet);
+            return false;
+        }
+
+        // languageID
+        if (tuple->items[8]->IsNone()) {
+            languageID = "";
+        } else if (tuple->items[8]->IsString()) {
+            languageID = tuple->items[8]->AsString()->content();
+        } else {
+            codelog(NET__PACKET_ERROR, "PyPacket::Decode() - Ninth main tuple element is neither string or none.");
+            PyDecRef(packet);
+            return false;
+        }
+    } else {
+        // For 7-element tuples, set defaults
+        contextKey = nullptr;
+        applicationID = "";
+        languageID = "";
+    }
+
     PyDecRef(packet);
     return true;
 }
 
 PyRep *PyPacket::Encode() {
-    PyTuple *arg_tuple = new PyTuple(7);
+    PyTuple *arg_tuple = new PyTuple(9);
     //command
     arg_tuple->items[0] = new PyInt(type);
     //source
@@ -266,6 +313,20 @@ PyRep *PyPacket::Encode() {
         arg_tuple->items[6] = PyStatic.NewNone();
     } else {
         arg_tuple->items[6] = contextKey;
+    }
+
+    // applicationID, used for routing
+    if (applicationID.empty()) {
+        arg_tuple->items[7] = PyStatic.NewNone();
+    } else {
+        arg_tuple->items[7] = new PyString(applicationID);
+    }
+
+    // languageID
+    if (languageID.empty()) {
+        arg_tuple->items[8] = PyStatic.NewNone();
+    } else {
+        arg_tuple->items[8] = new PyString(languageID);
     }
 
     return new PyObject( type_string.c_str(), arg_tuple );
@@ -608,7 +669,7 @@ bool PyCallStream::Decode(const std::string &type, PyTuple *&in_payload) {
         return false;
     }
 
-    if (type != "macho.CallReq") {
+    if (type != "macho.CallReq" && type != "carbon.common.script.net.machoNetPacket.CallReq") {
         codelog(NET__PACKET_ERROR, "PyCallStream::Decode() - packet payload has unknown string type '%s'", type.c_str());
         PyDecRef(payload);
         return false;

--- a/src/eve-common/python/PyPacket.h
+++ b/src/eve-common/python/PyPacket.h
@@ -119,6 +119,8 @@ public:
     PyTuple  *payload;
     PyDict   *named_payload;
     PyRep*      contextKey;
+    std::string applicationID;
+    std::string languageID;
 
 #if 0
     //options:

--- a/src/eve-server/CMakeLists.txt
+++ b/src/eve-server/CMakeLists.txt
@@ -143,7 +143,9 @@ SET( character_INCLUDE
      "${TARGET_INCLUDE_DIR}/character/PaperDollService.h"
      "${TARGET_INCLUDE_DIR}/character/PhotoUploadService.h"
      "${TARGET_INCLUDE_DIR}/character/Skill.h"
-     "${TARGET_INCLUDE_DIR}/character/SkillMgrService.h" )
+     "${TARGET_INCLUDE_DIR}/character/SkillMgrService.h"
+     "${TARGET_INCLUDE_DIR}/skillmgr2/SkillMgr2Service.h"
+     "${TARGET_INCLUDE_DIR}/skillmgr2/SkillHandler.h" )
 SET( character_SOURCE
      "${TARGET_SOURCE_DIR}/character/AggressionMgrService.cpp"
      "${TARGET_SOURCE_DIR}/character/CertificateMgrDB.cpp"
@@ -157,7 +159,9 @@ SET( character_SOURCE
      "${TARGET_SOURCE_DIR}/character/PaperDollService.cpp"
      "${TARGET_SOURCE_DIR}/character/PhotoUploadService.cpp"
      "${TARGET_SOURCE_DIR}/character/Skill.cpp"
-     "${TARGET_SOURCE_DIR}/character/SkillMgrService.cpp" )
+     "${TARGET_SOURCE_DIR}/character/SkillMgrService.cpp"
+     "${TARGET_SOURCE_DIR}/skillmgr2/SkillMgr2Service.cpp"
+     "${TARGET_SOURCE_DIR}/skillmgr2/SkillHandler.cpp" )
 
 SET( chat_INCLUDE
      "${TARGET_INCLUDE_DIR}/chat/LookupService.h"
@@ -225,6 +229,11 @@ SET( dogmaim_INCLUDE
 SET( dogmaim_SOURCE
      "${TARGET_SOURCE_DIR}/dogmaim/DogmaIMService.cpp"
      "${TARGET_SOURCE_DIR}/dogmaim/DogmaService.cpp" )
+
+SET( crimewatch_INCLUDE
+     "${TARGET_INCLUDE_DIR}/crimewatch/CrimewatchService.h")
+SET( crimewatch_SOURCE
+     "${TARGET_SOURCE_DIR}/crimewatch/CrimewatchService.cpp" )
 
 SET( dungeon_INCLUDE
      "${TARGET_INCLUDE_DIR}/dungeon/DungeonDB.h"
@@ -621,9 +630,23 @@ SET( system_managers_SOURCE
      "${TARGET_SOURCE_DIR}/system/cosmicMgrs/WormholeMgr.cpp")
 
 SET( test_INCLUDE
-    "${TARGET_INCLUDE_DIR}/testing/test.h")
+    "${TARGET_INCLUDE_DIR}/testing/test.h"
+    "${TARGET_INCLUDE_DIR}/projectdiscovery/ProjectDiscoveryService.h"
+    "${TARGET_INCLUDE_DIR}/eventlog/EventLogService.h"
+    "${TARGET_INCLUDE_DIR}/lscproxy/LSCProxyService.h"
+    "${TARGET_INCLUDE_DIR}/achievementtracker/AchievementTrackerMgrService.h"
+    "${TARGET_INCLUDE_DIR}/structuresettings/StructureSettingsService.h"
+    "${TARGET_INCLUDE_DIR}/structuredirectory/StructureDirectoryService.h"
+    "${TARGET_INCLUDE_DIR}/seasonmanager/SeasonManagerService.h")
 SET( test_SOURCE
-    "${TARGET_SOURCE_DIR}/testing/test.cpp")
+    "${TARGET_SOURCE_DIR}/testing/test.cpp"
+    "${TARGET_SOURCE_DIR}/projectdiscovery/ProjectDiscoveryService.cpp"
+    "${TARGET_SOURCE_DIR}/eventlog/EventLogService.cpp"
+    "${TARGET_SOURCE_DIR}/lscproxy/LSCProxyService.cpp"
+    "${TARGET_SOURCE_DIR}/achievementtracker/AchievementTrackerMgrService.cpp"
+    "${TARGET_SOURCE_DIR}/structuresettings/StructureSettingsService.cpp"
+    "${TARGET_SOURCE_DIR}/structuredirectory/StructureDirectoryService.cpp"
+    "${TARGET_SOURCE_DIR}/seasonmanager/SeasonManagerService.cpp")
 
 SET( services_INCLUDE
      "${TARGET_INCLUDE_DIR}/services/Service.h"
@@ -653,6 +676,7 @@ SOURCE_GROUP( "src\\config"        FILES ${config_INCLUDE} )
 SOURCE_GROUP( "src\\contract"      FILES ${contract_INCLUDE} )
 SOURCE_GROUP( "src\\corporation"   FILES ${corporation_INCLUDE} )
 SOURCE_GROUP( "src\\dogmaim"       FILES ${dogmaim_INCLUDE} )
+SOURCE_GROUP( "src\\crimewatch"    FILES ${crimewatch_INCLUDE} )
 SOURCE_GROUP( "src\\dungeon"       FILES ${dungeon_INCLUDE} )
 SOURCE_GROUP( "src\\effects"       FILES ${effects_INCLUDE} )
 SOURCE_GROUP( "src\\exploration"   FILES ${explore_INCLUDE} )
@@ -692,6 +716,7 @@ SOURCE_GROUP( "src\\config"        FILES ${config_SOURCE} )
 SOURCE_GROUP( "src\\contract"      FILES ${contract_SOURCE} )
 SOURCE_GROUP( "src\\corporation"   FILES ${corporation_SOURCE} )
 SOURCE_GROUP( "src\\dogmaim"       FILES ${dogmaim_SOURCE} )
+SOURCE_GROUP( "src\\crimewatch"    FILES ${crimewatch_SOURCE} )
 SOURCE_GROUP( "src\\dungeon"       FILES ${dungeon_SOURCE} )
 SOURCE_GROUP( "src\\effects"       FILES ${effects_SOURCE} )
 SOURCE_GROUP( "src\\exploration"   FILES ${explore_SOURCE} )
@@ -718,6 +743,20 @@ SOURCE_GROUP( "src\\system"        FILES ${system_SOURCE} )
 SOURCE_GROUP( "src\\system\\sov"   FILES ${system_sov_SOURCE} )
 SOURCE_GROUP( "src\\system\\cosmicMgrs"  FILES ${system_managers_SOURCE} )
 SOURCE_GROUP( "src\\system\\test"  FILES ${test_SOURCE} )
+SOURCE_GROUP( "src\\projectdiscovery"  FILES ${projectdiscovery_INCLUDE} )
+SOURCE_GROUP( "src\\projectdiscovery"  FILES ${projectdiscovery_SOURCE} )
+SOURCE_GROUP( "src\\eventlog"  FILES ${eventlog_INCLUDE} )
+SOURCE_GROUP( "src\\eventlog"  FILES ${eventlog_SOURCE} )
+SOURCE_GROUP( "src\\lscproxy"  FILES ${lscproxy_INCLUDE} )
+SOURCE_GROUP( "src\\lscproxy"  FILES ${lscproxy_SOURCE} )
+SOURCE_GROUP( "src\\achievementtracker"  FILES ${achievementtracker_INCLUDE} )
+SOURCE_GROUP( "src\\achievementtracker"  FILES ${achievementtracker_SOURCE} )
+SOURCE_GROUP( "src\\structuresettings"  FILES ${structuresettings_INCLUDE} )
+SOURCE_GROUP( "src\\structuresettings"  FILES ${structuresettings_SOURCE} )
+SOURCE_GROUP( "src\\structuredirectory"  FILES ${structuredirectory_INCLUDE} )
+SOURCE_GROUP( "src\\structuredirectory"  FILES ${structuredirectory_SOURCE} )
+SOURCE_GROUP( "src\\seasonmanager"  FILES ${seasonmanager_INCLUDE} )
+SOURCE_GROUP( "src\\seasonmanager"  FILES ${seasonmanager_SOURCE} )
 
 ADD_EXECUTABLE( "${TARGET_NAME}"
                 ${INCLUDE}                ${SOURCE}
@@ -732,6 +771,7 @@ ADD_EXECUTABLE( "${TARGET_NAME}"
                 ${contract_INCLUDE}       ${contract_SOURCE}
                 ${corporation_INCLUDE}    ${corporation_SOURCE}
                 ${dogmaim_INCLUDE}        ${dogmaim_SOURCE}
+                ${crimewatch_INCLUDE}     ${crimewatch_SOURCE}
                 ${dungeon_INCLUDE}        ${dungeon_SOURCE}
                 ${effects_INCLUDE}        ${effects_SOURCE}
                 ${explore_INCLUDE}        ${explore_SOURCE}
@@ -758,6 +798,14 @@ ADD_EXECUTABLE( "${TARGET_NAME}"
                 ${system_sov_INCLUDE}     ${system_sov_SOURCE}
                 ${system_managers_INCLUDE} ${system_managers_SOURCE}
                 ${test_INCLUDE}           ${test_SOURCE}
+                ${skillmgr2_INCLUDE}      ${skillmgr2_SOURCE}
+                ${projectdiscovery_INCLUDE} ${projectdiscovery_SOURCE}
+                ${eventlog_INCLUDE}       ${eventlog_SOURCE}
+                ${lscproxy_INCLUDE}       ${lscproxy_SOURCE}
+                ${achievementtracker_INCLUDE} ${achievementtracker_SOURCE}
+                ${structuresettings_INCLUDE} ${structuresettings_SOURCE}
+                ${structuredirectory_INCLUDE} ${structuredirectory_SOURCE}
+                ${seasonmanager_INCLUDE}    ${seasonmanager_SOURCE}
                 )
 
 target_precompile_headers( "${TARGET_NAME}" PUBLIC

--- a/src/eve-server/CMakeLists.txt
+++ b/src/eve-server/CMakeLists.txt
@@ -225,10 +225,12 @@ SET( corporation_SOURCE
 
 SET( dogmaim_INCLUDE
      "${TARGET_INCLUDE_DIR}/dogmaim/DogmaIMService.h"
-     "${TARGET_INCLUDE_DIR}/dogmaim/DogmaService.h")
+     "${TARGET_INCLUDE_DIR}/dogmaim/DogmaService.h"
+     "${TARGET_INCLUDE_DIR}/dogmaim/GodmaService.h")
 SET( dogmaim_SOURCE
      "${TARGET_SOURCE_DIR}/dogmaim/DogmaIMService.cpp"
-     "${TARGET_SOURCE_DIR}/dogmaim/DogmaService.cpp" )
+     "${TARGET_SOURCE_DIR}/dogmaim/DogmaService.cpp"
+     "${TARGET_SOURCE_DIR}/dogmaim/GodmaService.cpp" )
 
 SET( crimewatch_INCLUDE
      "${TARGET_INCLUDE_DIR}/crimewatch/CrimeWatchService.h")
@@ -476,13 +478,19 @@ SET( ship_INCLUDE
      "${TARGET_INCLUDE_DIR}/ship/Missile.h"
      "${TARGET_INCLUDE_DIR}/ship/Ship.h"
      "${TARGET_INCLUDE_DIR}/ship/ShipDB.h"
-     "${TARGET_INCLUDE_DIR}/ship/ShipService.h")
+     "${TARGET_INCLUDE_DIR}/ship/ShipService.h"
+     "${TARGET_INCLUDE_DIR}/ship/ShipSkinMgrService.h"
+     "${TARGET_INCLUDE_DIR}/ship/FighterMgrService.h"
+     "${TARGET_INCLUDE_DIR}/ship/ShipKillCounterService.h")
 SET( ship_SOURCE
      "${TARGET_SOURCE_DIR}/ship/BeyonceService.cpp"
      "${TARGET_SOURCE_DIR}/ship/Missile.cpp"
      "${TARGET_SOURCE_DIR}/ship/Ship.cpp"
      "${TARGET_SOURCE_DIR}/ship/ShipDB.cpp"
-     "${TARGET_SOURCE_DIR}/ship/ShipService.cpp" )
+     "${TARGET_SOURCE_DIR}/ship/ShipService.cpp"
+     "${TARGET_SOURCE_DIR}/ship/ShipSkinMgrService.cpp"
+     "${TARGET_SOURCE_DIR}/ship/FighterMgrService.cpp"
+     "${TARGET_SOURCE_DIR}/ship/ShipKillCounterService.cpp")
 
 SET( ship_modules_INCLUDE
      "${TARGET_INCLUDE_DIR}/ship/modules/ActiveModule.h"
@@ -521,6 +529,11 @@ SET( standing_SOURCE
      "${TARGET_SOURCE_DIR}/standing/Standing.cpp"
      "${TARGET_SOURCE_DIR}/standing/StandingDB.cpp"
      "${TARGET_SOURCE_DIR}/standing/StandingMgr.cpp" )
+
+SET( bounty_INCLUDE
+     "${TARGET_INCLUDE_DIR}/bounty/BountyProxyService.h" )
+SET( bounty_SOURCE
+     "${TARGET_SOURCE_DIR}/bounty/BountyProxyService.cpp" )
 
 SET( station_INCLUDE
      "${TARGET_INCLUDE_DIR}/station/HoloscreenMgrService.h"
@@ -648,6 +661,41 @@ SET( test_SOURCE
     "${TARGET_SOURCE_DIR}/structuredirectory/StructureDirectoryService.cpp"
     "${TARGET_SOURCE_DIR}/seasonmanager/SeasonManagerService.cpp")
 
+SET( projectdiscovery_INCLUDE
+     "${TARGET_INCLUDE_DIR}/projectdiscovery/ProjectDiscoveryService.h")
+SET( projectdiscovery_SOURCE
+     "${TARGET_SOURCE_DIR}/projectdiscovery/ProjectDiscoveryService.cpp")
+
+SET( eventlog_INCLUDE
+     "${TARGET_INCLUDE_DIR}/eventlog/EventLogService.h")
+SET( eventlog_SOURCE
+     "${TARGET_SOURCE_DIR}/eventlog/EventLogService.cpp")
+
+SET( lscproxy_INCLUDE
+     "${TARGET_INCLUDE_DIR}/lscproxy/LSCProxyService.h")
+SET( lscproxy_SOURCE
+     "${TARGET_SOURCE_DIR}/lscproxy/LSCProxyService.cpp")
+
+SET( achievementtracker_INCLUDE
+     "${TARGET_INCLUDE_DIR}/achievementtracker/AchievementTrackerMgrService.h")
+SET( achievementtracker_SOURCE
+     "${TARGET_SOURCE_DIR}/achievementtracker/AchievementTrackerMgrService.cpp")
+
+SET( structuresettings_INCLUDE
+     "${TARGET_INCLUDE_DIR}/structuresettings/StructureSettingsService.h")
+SET( structuresettings_SOURCE
+     "${TARGET_SOURCE_DIR}/structuresettings/StructureSettingsService.cpp")
+
+SET( structuredirectory_INCLUDE
+     "${TARGET_INCLUDE_DIR}/structuredirectory/StructureDirectoryService.h")
+SET( structuredirectory_SOURCE
+     "${TARGET_SOURCE_DIR}/structuredirectory/StructureDirectoryService.cpp")
+
+SET( seasonmanager_INCLUDE
+     "${TARGET_INCLUDE_DIR}/seasonmanager/SeasonManagerService.h")
+SET( seasonmanager_SOURCE
+     "${TARGET_SOURCE_DIR}/seasonmanager/SeasonManagerService.cpp")
+
 SET( services_INCLUDE
      "${TARGET_INCLUDE_DIR}/services/Service.h"
      "${TARGET_INCLUDE_DIR}/services/Callable.h"
@@ -698,6 +746,7 @@ SOURCE_GROUP( "src\\services"      FILES ${services_INCLUDE} )
 SOURCE_GROUP( "src\\ship"          FILES ${ship_INCLUDE} )
 SOURCE_GROUP( "src\\ship\\modules" FILES ${ship_modules_INCLUDE} )
 SOURCE_GROUP( "src\\standing"      FILES ${standing_INCLUDE} )
+SOURCE_GROUP( "src\\bounty"        FILES ${bounty_INCLUDE} )
 SOURCE_GROUP( "src\\station"       FILES ${station_INCLUDE} )
 SOURCE_GROUP( "src\\system"        FILES ${system_INCLUDE} )
 SOURCE_GROUP( "src\\system\\sov"   FILES ${system_sov_INCLUDE} )
@@ -738,6 +787,7 @@ SOURCE_GROUP( "src\\services"      FILES ${services_SOURCE} )
 SOURCE_GROUP( "src\\ship"          FILES ${ship_SOURCE} )
 SOURCE_GROUP( "src\\ship\\modules" FILES ${ship_modules_SOURCE} )
 SOURCE_GROUP( "src\\standing"      FILES ${standing_SOURCE} )
+SOURCE_GROUP( "src\\bounty"        FILES ${bounty_SOURCE} )
 SOURCE_GROUP( "src\\station"       FILES ${station_SOURCE} )
 SOURCE_GROUP( "src\\system"        FILES ${system_SOURCE} )
 SOURCE_GROUP( "src\\system\\sov"   FILES ${system_sov_SOURCE} )
@@ -793,6 +843,7 @@ ADD_EXECUTABLE( "${TARGET_NAME}"
                 ${ship_INCLUDE}           ${ship_SOURCE}
                 ${ship_modules_INCLUDE}   ${ship_modules_SOURCE}
                 ${standing_INCLUDE}       ${standing_SOURCE}
+                ${bounty_INCLUDE}        ${bounty_SOURCE}
                 ${station_INCLUDE}        ${station_SOURCE}
                 ${system_INCLUDE}         ${system_SOURCE}
                 ${system_sov_INCLUDE}     ${system_sov_SOURCE}

--- a/src/eve-server/CMakeLists.txt
+++ b/src/eve-server/CMakeLists.txt
@@ -231,9 +231,9 @@ SET( dogmaim_SOURCE
      "${TARGET_SOURCE_DIR}/dogmaim/DogmaService.cpp" )
 
 SET( crimewatch_INCLUDE
-     "${TARGET_INCLUDE_DIR}/crimewatch/CrimewatchService.h")
+     "${TARGET_INCLUDE_DIR}/crimewatch/CrimeWatchService.h")
 SET( crimewatch_SOURCE
-     "${TARGET_SOURCE_DIR}/crimewatch/CrimewatchService.cpp" )
+     "${TARGET_SOURCE_DIR}/crimewatch/CrimeWatchService.cpp" )
 
 SET( dungeon_INCLUDE
      "${TARGET_INCLUDE_DIR}/dungeon/DungeonDB.h"

--- a/src/eve-server/Client.cpp
+++ b/src/eve-server/Client.cpp
@@ -2021,18 +2021,18 @@ void Client::InitSession(int32 characterID)
      */
     if (sDataMgr.IsStation(stationID)) {
         m_locationID = stationID;
-        pSession->Clear("solarsystemid");    //must be 0 in station
-        pSession->Clear("shipid");    //must be 0 in station
+        pSession->Clear("solarsystemid");
+        pSession->Clear("shipid");
         pSession->SetInt("stationid", stationID);
         pSession->SetInt("stationid2", stationID);
         pSession->SetInt("locationid", stationID);
         pSession->SetInt("worldspaceid", stationID);
-        pSession->SetInt("structureid", stationID);
+        pSession->Clear("structureid");
     } else {
         m_locationID = solarSystemID;
-        pSession->Clear("stationid");   //must be 0 in space
-        pSession->Clear("stationid2");  //must be 0 in space
-        pSession->Clear("worldspaceid");  //must be 0 in space
+        pSession->Clear("stationid");
+        pSession->Clear("stationid2");
+        pSession->Clear("worldspaceid");
         pSession->SetInt("shipid", m_shipId);
         pSession->SetInt("solarsystemid", solarSystemID);
         pSession->SetInt("locationid", solarSystemID);
@@ -2060,15 +2060,15 @@ void Client::UpdateSession()
         //pSession->Clear("worldspaceid");    //not used here (yet)
 
         pSession->SetInt("stationid", stationID);
-        pSession->SetInt("stationid2", stationID);   // client uses this for continer location checks
+        pSession->SetInt("stationid2", stationID);
         pSession->SetInt("worldspaceid", stationID);
         pSession->SetInt("locationid", stationID);
-        pSession->SetInt("structureid", stationID);
+        pSession->Clear("structureid");
     } else {
         pSession->Clear("stationid");
         pSession->Clear("stationid2");
         pSession->Clear("worldspaceid");
-        pSession->SetInt("solarsystemid", solarsystemID); //  used to tell client they are in space
+        pSession->SetInt("solarsystemid", solarsystemID);
         pSession->SetInt("locationid", solarsystemID);
         pSession->SetInt("shipid", m_shipId);
         pSession->Clear("structureid");

--- a/src/eve-server/Client.cpp
+++ b/src/eve-server/Client.cpp
@@ -2022,7 +2022,7 @@ void Client::InitSession(int32 characterID)
     if (sDataMgr.IsStation(stationID)) {
         m_locationID = stationID;
         pSession->Clear("solarsystemid");
-        pSession->Clear("shipid");
+        pSession->SetInt("shipid", m_shipId);
         pSession->SetInt("stationid", stationID);
         pSession->SetInt("stationid2", stationID);
         pSession->SetInt("locationid", stationID);
@@ -2056,7 +2056,7 @@ void Client::UpdateSession()
     uint32 solarsystemID = m_char->solarSystemID();
     if (sDataMgr.IsStation(stationID)) {
         pSession->Clear("solarsystemid");    //must be 0 in station
-        pSession->Clear("shipid");    //must be 0 in station
+        pSession->SetInt("shipid", m_shipId);
         //pSession->Clear("worldspaceid");    //not used here (yet)
 
         pSession->SetInt("stationid", stationID);

--- a/src/eve-server/Client.cpp
+++ b/src/eve-server/Client.cpp
@@ -2027,6 +2027,7 @@ void Client::InitSession(int32 characterID)
         pSession->SetInt("stationid2", stationID);
         pSession->SetInt("locationid", stationID);
         pSession->SetInt("worldspaceid", stationID);
+        pSession->SetInt("structureid", stationID);
     } else {
         m_locationID = solarSystemID;
         pSession->Clear("stationid");   //must be 0 in space
@@ -2035,6 +2036,7 @@ void Client::InitSession(int32 characterID)
         pSession->SetInt("shipid", m_shipId);
         pSession->SetInt("solarsystemid", solarSystemID);
         pSession->SetInt("locationid", solarSystemID);
+        pSession->Clear("structureid");
     }
 
     sDataMgr.GetSystemData(m_locationID, m_systemData);
@@ -2061,6 +2063,7 @@ void Client::UpdateSession()
         pSession->SetInt("stationid2", stationID);   // client uses this for continer location checks
         pSession->SetInt("worldspaceid", stationID);
         pSession->SetInt("locationid", stationID);
+        pSession->SetInt("structureid", stationID);
     } else {
         pSession->Clear("stationid");
         pSession->Clear("stationid2");
@@ -2068,6 +2071,7 @@ void Client::UpdateSession()
         pSession->SetInt("solarsystemid", solarsystemID); //  used to tell client they are in space
         pSession->SetInt("locationid", solarsystemID);
         pSession->SetInt("shipid", m_shipId);
+        pSession->Clear("structureid");
     }
 
     // solarsystemid2 is used by client to determine current system.  NOTE:  *MUST* be set to current system.

--- a/src/eve-server/Client.h
+++ b/src/eve-server/Client.h
@@ -206,6 +206,7 @@ public:
     void UpdateBubble();
     void WarpIn();
     void WarpOut();
+    void SaveLocationData(const char* customInfoPrefix = nullptr);  // Shared helper for saving location data
     void EnterSystem(uint32 systemID);     // only called by gm command, and only if (bubble == null)
     // this will accept null coords and adjust position to random moon
     void MoveToLocation(uint32 location, const GPoint &pt);

--- a/src/eve-server/account/ClientStatMgrService.cpp
+++ b/src/eve-server/account/ClientStatMgrService.cpp
@@ -29,7 +29,7 @@
 #include "account/ClientStatMgrService.h"
 
 ClientStatsMgr::ClientStatsMgr() :
-    Service("clientStatsMgr")
+    Service("clientStats")
 {
     this->Add("SubmitStats", &ClientStatsMgr::SubmitStats);
 }

--- a/src/eve-server/achievementtracker/AchievementTrackerMgrService.cpp
+++ b/src/eve-server/achievementtracker/AchievementTrackerMgrService.cpp
@@ -34,6 +34,7 @@ AchievementTrackerMgrService::AchievementTrackerMgrService() :
     this->Add("GetProgressForAchievement", &AchievementTrackerMgrService::GetProgressForAchievement);
     this->Add("GetProgressForChar", &AchievementTrackerMgrService::GetProgressForChar);
     this->Add("GetProgressForCharAndAchievement", &AchievementTrackerMgrService::GetProgressForCharAndAchievement);
+    this->Add("GetCompletedAchievementsAndClientEventCount", &AchievementTrackerMgrService::GetCompletedAchievementsAndClientEventCount);
 }
 
 PyResult AchievementTrackerMgrService::GetAchievements(PyCallArgs& call)
@@ -70,4 +71,15 @@ PyResult AchievementTrackerMgrService::GetProgressForCharAndAchievement(PyCallAr
 {
     sLog.Debug("AchievementTrackerMgrService", "GetProgressForCharAndAchievement called - stub");
     return new PyDict();
+}
+
+PyResult AchievementTrackerMgrService::GetCompletedAchievementsAndClientEventCount(PyCallArgs& call)
+{
+    sLog.Debug("AchievementTrackerMgrService", "GetCompletedAchievementsAndClientEventCount called - returning empty dicts");
+    
+    PyDict* result = new PyDict();
+    result->SetItemString("completedDict", new PyDict());
+    result->SetItemString("eventDict", new PyDict());
+    
+    return result;
 }

--- a/src/eve-server/achievementtracker/AchievementTrackerMgrService.cpp
+++ b/src/eve-server/achievementtracker/AchievementTrackerMgrService.cpp
@@ -1,0 +1,73 @@
+/*
+    ------------------------------------------------------------------------------------
+    LICENSE:
+    ------------------------------------------------------------------------------------
+    This file is part of EVEmu: EVE Online Server Emulator
+    Copyright 2006 - 2021 The EVEmu Team
+    For the latest information visit https://evemu.dev
+    ------------------------------------------------------------------------------------
+    This program is free software; you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License as published by the Free Software
+    Foundation; either version 2 of the License, or (at your option) any later
+    version.
+    This program is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+    FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+    You should have received a copy of the GNU Lesser General Public License along with
+    this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+    Place - Suite 330, Boston, MA 02111-1307, USA, or go to
+    http://www.gnu.org/copyleft/lesser.txt.
+    ------------------------------------------------------------------------------------
+    Author: Zhur
+*/
+
+#include "eve-server.h"
+
+#include "achievementtracker/AchievementTrackerMgrService.h"
+
+AchievementTrackerMgrService::AchievementTrackerMgrService() :
+    Service("achievementTrackerMgr")
+{
+    this->Add("GetAchievements", &AchievementTrackerMgrService::GetAchievements);
+    this->Add("GetAchievement", &AchievementTrackerMgrService::GetAchievement);
+    this->Add("GetProgress", &AchievementTrackerMgrService::GetProgress);
+    this->Add("GetProgressForAchievement", &AchievementTrackerMgrService::GetProgressForAchievement);
+    this->Add("GetProgressForChar", &AchievementTrackerMgrService::GetProgressForChar);
+    this->Add("GetProgressForCharAndAchievement", &AchievementTrackerMgrService::GetProgressForCharAndAchievement);
+}
+
+PyResult AchievementTrackerMgrService::GetAchievements(PyCallArgs& call)
+{
+    sLog.Debug("AchievementTrackerMgrService", "GetAchievements called - stub");
+    return new PyList();
+}
+
+PyResult AchievementTrackerMgrService::GetAchievement(PyCallArgs& call)
+{
+    sLog.Debug("AchievementTrackerMgrService", "GetAchievement called - stub");
+    return PyStatic.NewNone();
+}
+
+PyResult AchievementTrackerMgrService::GetProgress(PyCallArgs& call)
+{
+    sLog.Debug("AchievementTrackerMgrService", "GetProgress called - stub");
+    return new PyDict();
+}
+
+PyResult AchievementTrackerMgrService::GetProgressForAchievement(PyCallArgs& call)
+{
+    sLog.Debug("AchievementTrackerMgrService", "GetProgressForAchievement called - stub");
+    return new PyDict();
+}
+
+PyResult AchievementTrackerMgrService::GetProgressForChar(PyCallArgs& call)
+{
+    sLog.Debug("AchievementTrackerMgrService", "GetProgressForChar called - stub");
+    return new PyDict();
+}
+
+PyResult AchievementTrackerMgrService::GetProgressForCharAndAchievement(PyCallArgs& call)
+{
+    sLog.Debug("AchievementTrackerMgrService", "GetProgressForCharAndAchievement called - stub");
+    return new PyDict();
+}

--- a/src/eve-server/achievementtracker/AchievementTrackerMgrService.h
+++ b/src/eve-server/achievementtracker/AchievementTrackerMgrService.h
@@ -37,6 +37,7 @@ protected:
     PyResult GetProgressForAchievement(PyCallArgs &call);
     PyResult GetProgressForChar(PyCallArgs &call);
     PyResult GetProgressForCharAndAchievement(PyCallArgs &call);
+    PyResult GetCompletedAchievementsAndClientEventCount(PyCallArgs &call);
 };
 
 #endif

--- a/src/eve-server/achievementtracker/AchievementTrackerMgrService.h
+++ b/src/eve-server/achievementtracker/AchievementTrackerMgrService.h
@@ -1,0 +1,42 @@
+/*
+    ------------------------------------------------------------------------------------
+    LICENSE:
+    ------------------------------------------------------------------------------------
+    This file is part of EVEmu: EVE Online Server Emulator
+    Copyright 2006 - 2021 The EVEmu Team
+    For the latest information visit https://evemu.dev
+    ------------------------------------------------------------------------------------
+    This program is free software; you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License as published by the Free Software
+    Foundation; either version 2 of the License, or (at your option) any later
+    version.
+    This program is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+    FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+    You should have received a copy of the GNU Lesser General Public License along with
+    this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+    Place - Suite 330, Boston, MA 02111-1307, USA, or go to
+    http://www.gnu.org/copyleft/lesser.txt.
+    ------------------------------------------------------------------------------------
+    Author: Zhur
+*/
+
+#ifndef __ACHIEVEMENTTRACKER_SERVICE_H_INCL__
+#define __ACHIEVEMENTTRACKER_SERVICE_H_INCL__
+
+#include "services/Service.h"
+
+class AchievementTrackerMgrService : public Service <AchievementTrackerMgrService> {
+public:
+    AchievementTrackerMgrService();
+
+protected:
+    PyResult GetAchievements(PyCallArgs &call);
+    PyResult GetAchievement(PyCallArgs &call);
+    PyResult GetProgress(PyCallArgs &call);
+    PyResult GetProgressForAchievement(PyCallArgs &call);
+    PyResult GetProgressForChar(PyCallArgs &call);
+    PyResult GetProgressForCharAndAchievement(PyCallArgs &call);
+};
+
+#endif

--- a/src/eve-server/agents/AgentMgrService.cpp
+++ b/src/eve-server/agents/AgentMgrService.cpp
@@ -65,6 +65,7 @@ AgentMgrService::AgentMgrService(EVEServiceManager& mgr) :
     this->Add("GetMyJournalDetails", &AgentMgrService::GetMyJournalDetails);
     this->Add("GetSolarSystemOfAgent", &AgentMgrService::GetSolarSystemOfAgent);
     this->Add("GetMyEpicJournalDetails", &AgentMgrService::GetMyEpicJournalDetails);
+    this->Add("GetAgentsInSpace", &AgentMgrService::GetAgentsInSpace);
 }
 
 BoundDispatcher* AgentMgrService::BindObject(Client* client, PyRep* bindParameters) {
@@ -140,7 +141,7 @@ PyResult AgentMgrService::GetMyJournalDetails(PyCallArgs &call) {
     std::vector<MissionOffer> data;
     sMissionDataMgr.LoadMissionOffers(call.client->GetCharacterID(), data);
     for (auto cur : data) {
-        PyTuple* mData = new PyTuple(9);
+        PyTuple* mData = new PyTuple(10);
         mData->SetItem(0, new PyInt(cur.stateID)); //missionState  .. these may be wrong also.
         mData->SetItem(1, new PyInt(cur.important?1:0)); //importantMission  -- integer boolean
         mData->SetItem(2, new PyString(sMissionDataMgr.GetTypeLabel(cur.typeID))); //missionTypeLabel
@@ -150,6 +151,7 @@ PyResult AgentMgrService::GetMyJournalDetails(PyCallArgs &call) {
         mData->SetItem(6, cur.bookmarks->Clone()); //bookmarks -- if populated, this is PyList of PyDicts as defined below...
         mData->SetItem(7, new PyBool(cur.remoteOfferable)); //remoteOfferable
         mData->SetItem(8, new PyBool(cur.remoteCompletable)); //remoteCompletable
+        mData->SetItem(9, new PyInt(cur.contentID)); //contentID
         missions->AddItem(mData);
     }
     tuple->SetItem(0, missions);
@@ -292,6 +294,13 @@ PyResult AgentMgrService::GetCareerAgents(PyCallArgs &call)
     call.Dump(AGENT__DUMP);
 
     return PyStatic.NewZero();
+}
+
+PyResult AgentMgrService::GetAgentsInSpace(PyCallArgs &call)
+{
+    sLog.Debug("AgentMgrService", "GetAgentsInSpace called - returning empty dict");
+    PyDict* result = new PyDict();
+    return result;
 }
 
 EpicArcService::EpicArcService() :

--- a/src/eve-server/agents/AgentMgrService.h
+++ b/src/eve-server/agents/AgentMgrService.h
@@ -46,6 +46,7 @@ protected:
     PyResult GetMyJournalDetails(PyCallArgs& call);
     PyResult GetMyEpicJournalDetails(PyCallArgs& call);
     PyResult GetCareerAgents(PyCallArgs& call);
+    PyResult GetAgentsInSpace(PyCallArgs& call);
 
     //overloaded in order to support bound objects:
     BoundDispatcher* BindObject(Client *client, PyRep* bindParameters) override;

--- a/src/eve-server/bounty/BountyProxyService.cpp
+++ b/src/eve-server/bounty/BountyProxyService.cpp
@@ -1,0 +1,255 @@
+/*
+    ------------------------------------------------------------------------------------
+    LICENSE:
+    ------------------------------------------------------------------------------------
+    This file is part of EVEmu: EVE Online Server Emulator
+    Copyright 2006 - 2021 The EVEmu Team
+    For the latest information visit https://evemu.dev
+    ------------------------------------------------------------------------------------
+    This program is free software; you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License as published by the Free Software
+    Foundation; either version 2 of the License, or (at your option) any later
+    version.
+
+    This program is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+    FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License along with
+    this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+    Place - Suite 330, Boston, MA 02111-1307, USA, or go to
+    http://www.gnu.org/copyleft/lesser.txt.
+    ------------------------------------------------------------------------------------
+    Author:     Zhur
+*/
+
+#include "eve-server.h"
+
+#include "bounty/BountyProxyService.h"
+
+BountyProxyService::BountyProxyService() :
+    Service<BountyProxyService>("bountyProxy")
+{
+    this->Add("GetBounties", &BountyProxyService::GetBounties);
+    this->Add("GetMyBounties", &BountyProxyService::GetMyBounties);
+    this->Add("GetTopPilotBounties", &BountyProxyService::GetTopPilotBounties);
+    this->Add("GetTopCorpBounties", &BountyProxyService::GetTopCorpBounties);
+    this->Add("GetTopAllianceBounties", &BountyProxyService::GetTopAllianceBounties);
+    this->Add("GetTopPilotBountyHunters", &BountyProxyService::GetTopPilotBountyHunters);
+    this->Add("GetTopCorporationBountyHunters", &BountyProxyService::GetTopCorporationBountyHunters);
+    this->Add("GetTopAllianceBountyHunters", &BountyProxyService::GetTopAllianceBountyHunters);
+    this->Add("AddToBounty", &BountyProxyService::AddToBounty);
+    this->Add("SearchCharBounties", &BountyProxyService::SearchCharBounties);
+    this->Add("SearchCorpBounties", &BountyProxyService::SearchCorpBounties);
+    this->Add("SearchAllianceBounties", &BountyProxyService::SearchAllianceBounties);
+    this->Add("GetBountiesAndKillRights", &BountyProxyService::GetBountiesAndKillRights);
+    this->Add("SellKillRight", &BountyProxyService::SellKillRight);
+    this->Add("CancelSellKillRight", &BountyProxyService::CancelSellKillRight);
+    this->Add("GMReimburseBounties", &BountyProxyService::GMReimburseBounties);
+    this->Add("GMClearBountyCache", &BountyProxyService::GMClearBountyCache);
+}
+
+BountyProxyService::~BountyProxyService()
+{
+}
+
+PyResult BountyProxyService::GetBounties(PyCallArgs& call, PyRep* ownerIDs)
+{
+    sLog.Debug("BountyProxyService", "GetBounties called");
+    
+    PyDict* result = new PyDict();
+    
+    if (ownerIDs != nullptr) {
+        PyList* idList = nullptr;
+        
+        // Try to convert to list (handles both list and set)
+        if (ownerIDs->IsList()) {
+            idList = ownerIDs->AsList();
+        } else if (ownerIDs->IsDict()) {
+            // set might be serialized as dict
+            PyDict* idDict = ownerIDs->AsDict();
+            if (idDict != nullptr) {
+                // Create a list from dict keys
+                idList = new PyList();
+                for (PyDict::const_iterator itr = idDict->begin(); itr != idDict->end(); ++itr) {
+                    idList->AddItem(itr->first->Clone());
+                }
+            }
+        } else if (ownerIDs->IsTuple()) {
+            // Handle tuple as well
+            PyTuple* idTuple = ownerIDs->AsTuple();
+            if (idTuple != nullptr) {
+                idList = new PyList();
+                for (size_t i = 0; i < idTuple->size(); ++i) {
+                    idList->AddItem(idTuple->GetItem(i)->Clone());
+                }
+            }
+        }
+        
+        if (idList != nullptr) {
+            for (size_t i = 0; i < idList->size(); ++i) {
+                PyInt* ownerID = idList->GetItem(i)->AsInt();
+                if (ownerID != nullptr) {
+                    // Create a list containing a dict with bounty information
+                    PyList* bountyList = new PyList();
+                    
+                    // Create a bounty object (util.KeyVal with bounty field)
+                    PyDict* bountyObj = new PyDict();
+                    bountyObj->SetItemString("bounty", new PyFloat(0.0));
+                    bountyObj->SetItemString("ownerID", new PyInt(ownerID->value()));
+                    
+                    PyObject* bountyKeyVal = new PyObject("util.KeyVal", bountyObj);
+                    bountyList->AddItem(bountyKeyVal);
+                    
+                    result->SetItem(new PyInt(ownerID->value()), bountyList);
+                }
+            }
+        }
+    }
+    
+    return result;
+}
+
+PyResult BountyProxyService::GetMyBounties(PyCallArgs& call)
+{
+    sLog.Debug("BountyProxyService", "GetMyBounties called");
+    PyList* result = new PyList();
+    return result;
+}
+
+PyResult BountyProxyService::GetTopPilotBounties(PyCallArgs& call, PyInt* page)
+{
+    sLog.Debug("BountyProxyService", "GetTopPilotBounties called with page %d", page ? page->value() : 0);
+    
+    PyTuple* result = new PyTuple(2);
+    result->SetItem(0, new PyList());
+    result->SetItem(1, new PyLong(GetFileTimeNow()));
+    
+    return result;
+}
+
+PyResult BountyProxyService::GetTopCorpBounties(PyCallArgs& call, PyInt* page)
+{
+    sLog.Debug("BountyProxyService", "GetTopCorpBounties called with page %d", page ? page->value() : 0);
+    
+    PyTuple* result = new PyTuple(2);
+    result->SetItem(0, new PyList());
+    result->SetItem(1, new PyLong(GetFileTimeNow()));
+    
+    return result;
+}
+
+PyResult BountyProxyService::GetTopAllianceBounties(PyCallArgs& call, PyInt* page)
+{
+    sLog.Debug("BountyProxyService", "GetTopAllianceBounties called with page %d", page ? page->value() : 0);
+    
+    PyTuple* result = new PyTuple(2);
+    result->SetItem(0, new PyList());
+    result->SetItem(1, new PyLong(GetFileTimeNow()));
+    
+    return result;
+}
+
+PyResult BountyProxyService::GetTopPilotBountyHunters(PyCallArgs& call, PyInt* page)
+{
+    sLog.Debug("BountyProxyService", "GetTopPilotBountyHunters called with page %d", page ? page->value() : 0);
+    
+    PyTuple* result = new PyTuple(2);
+    result->SetItem(0, new PyList());
+    result->SetItem(1, new PyLong(GetFileTimeNow()));
+    
+    return result;
+}
+
+PyResult BountyProxyService::GetTopCorporationBountyHunters(PyCallArgs& call, PyInt* page)
+{
+    sLog.Debug("BountyProxyService", "GetTopCorporationBountyHunters called with page %d", page ? page->value() : 0);
+    
+    PyTuple* result = new PyTuple(2);
+    result->SetItem(0, new PyList());
+    result->SetItem(1, new PyLong(GetFileTimeNow()));
+    
+    return result;
+}
+
+PyResult BountyProxyService::GetTopAllianceBountyHunters(PyCallArgs& call, PyInt* page)
+{
+    sLog.Debug("BountyProxyService", "GetTopAllianceBountyHunters called with page %d", page ? page->value() : 0);
+    
+    PyTuple* result = new PyTuple(2);
+    result->SetItem(0, new PyList());
+    result->SetItem(1, new PyLong(GetFileTimeNow()));
+    
+    return result;
+}
+
+PyResult BountyProxyService::AddToBounty(PyCallArgs& call, PyInt* ownerID, PyInt* amount)
+{
+    sLog.Debug("BountyProxyService", "AddToBounty called for owner %u amount %d", 
+               ownerID ? ownerID->value() : 0, amount ? amount->value() : 0);
+    
+    return new PyFloat(0.0);
+}
+
+PyResult BountyProxyService::SearchCharBounties(PyCallArgs& call, PyInt* charID)
+{
+    sLog.Debug("BountyProxyService", "SearchCharBounties called for char %u", charID ? charID->value() : 0);
+    
+    PyList* result = new PyList();
+    return result;
+}
+
+PyResult BountyProxyService::SearchCorpBounties(PyCallArgs& call, PyInt* corpID)
+{
+    sLog.Debug("BountyProxyService", "SearchCorpBounties called for corp %u", corpID ? corpID->value() : 0);
+    
+    PyList* result = new PyList();
+    return result;
+}
+
+PyResult BountyProxyService::SearchAllianceBounties(PyCallArgs& call, PyInt* allianceID)
+{
+    sLog.Debug("BountyProxyService", "SearchAllianceBounties called for alliance %u", allianceID ? allianceID->value() : 0);
+    
+    PyList* result = new PyList();
+    return result;
+}
+
+PyResult BountyProxyService::GetBountiesAndKillRights(PyCallArgs& call, PyList* bountiesToFetch, PyList* killRightsToFetch)
+{
+    sLog.Debug("BountyProxyService", "GetBountiesAndKillRights called");
+    
+    PyTuple* result = new PyTuple(2);
+    result->SetItem(0, new PyList());
+    result->SetItem(1, new PyList());
+    
+    return result;
+}
+
+PyResult BountyProxyService::SellKillRight(PyCallArgs& call, PyInt* killRightID, PyInt* price, PyRep* restrictedTo)
+{
+    sLog.Debug("BountyProxyService", "SellKillRight called for killRight %u price %d", 
+               killRightID ? killRightID->value() : 0, price ? price->value() : 0);
+    
+    return PyStatic.NewNone();
+}
+
+PyResult BountyProxyService::CancelSellKillRight(PyCallArgs& call, PyInt* killRightID, PyInt* toID)
+{
+    sLog.Debug("BountyProxyService", "CancelSellKillRight called for killRight %u to %u", 
+               killRightID ? killRightID->value() : 0, toID ? toID->value() : 0);
+    
+    return PyStatic.NewNone();
+}
+
+PyResult BountyProxyService::GMReimburseBounties(PyCallArgs& call)
+{
+    sLog.Debug("BountyProxyService", "GMReimburseBounties called");
+    return PyStatic.NewNone();
+}
+
+PyResult BountyProxyService::GMClearBountyCache(PyCallArgs& call)
+{
+    sLog.Debug("BountyProxyService", "GMClearBountyCache called");
+    return PyStatic.NewNone();
+}

--- a/src/eve-server/bounty/BountyProxyService.h
+++ b/src/eve-server/bounty/BountyProxyService.h
@@ -1,0 +1,58 @@
+/*
+    ------------------------------------------------------------------------------------
+    LICENSE:
+    ------------------------------------------------------------------------------------
+    This file is part of EVEmu: EVE Online Server Emulator
+    Copyright 2006 - 2021 The EVEmu Team
+    For the latest information visit https://evemu.dev
+    ------------------------------------------------------------------------------------
+    This program is free software; you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License as published by the Free Software
+    Foundation; either version 2 of the License, or (at your option) any later
+    version.
+
+    This program is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+    FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License along with
+    this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+    Place - Suite 330, Boston, MA 02111-1307, USA, or go to
+    http://www.gnu.org/copyleft/lesser.txt.
+    ------------------------------------------------------------------------------------
+    Author:     Zhur
+*/
+
+#ifndef __BOUNTYPROXYSERVICE_H_INCL__
+#define __BOUNTYPROXYSERVICE_H_INCL__
+
+#include "eve-server.h"
+
+#include "services/Service.h"
+
+class BountyProxyService : public Service<BountyProxyService> {
+public:
+    BountyProxyService();
+    virtual ~BountyProxyService();
+
+protected:
+    PyResult GetBounties(PyCallArgs& call, PyRep* ownerIDs);
+    PyResult GetMyBounties(PyCallArgs& call);
+    PyResult GetTopPilotBounties(PyCallArgs& call, PyInt* page);
+    PyResult GetTopCorpBounties(PyCallArgs& call, PyInt* page);
+    PyResult GetTopAllianceBounties(PyCallArgs& call, PyInt* page);
+    PyResult GetTopPilotBountyHunters(PyCallArgs& call, PyInt* page);
+    PyResult GetTopCorporationBountyHunters(PyCallArgs& call, PyInt* page);
+    PyResult GetTopAllianceBountyHunters(PyCallArgs& call, PyInt* page);
+    PyResult AddToBounty(PyCallArgs& call, PyInt* ownerID, PyInt* amount);
+    PyResult SearchCharBounties(PyCallArgs& call, PyInt* charID);
+    PyResult SearchCorpBounties(PyCallArgs& call, PyInt* corpID);
+    PyResult SearchAllianceBounties(PyCallArgs& call, PyInt* allianceID);
+    PyResult GetBountiesAndKillRights(PyCallArgs& call, PyList* bountiesToFetch, PyList* killRightsToFetch);
+    PyResult SellKillRight(PyCallArgs& call, PyInt* killRightID, PyInt* price, PyRep* restrictedTo);
+    PyResult CancelSellKillRight(PyCallArgs& call, PyInt* killRightID, PyInt* toID);
+    PyResult GMReimburseBounties(PyCallArgs& call);
+    PyResult GMClearBountyCache(PyCallArgs& call);
+};
+
+#endif

--- a/src/eve-server/character/CharMgrService.cpp
+++ b/src/eve-server/character/CharMgrService.cpp
@@ -123,6 +123,7 @@ CharMgrService::CharMgrService(EVEServiceManager& mgr) :
     this->Add("GetFactions", &CharMgrService::GetFactions);
     this->Add("SetActivityStatus", &CharMgrService::SetActivityStatus);
     this->Add("GetSettingsInfo", &CharMgrService::GetSettingsInfo);
+    this->Add("GetCharacterSettings", &CharMgrService::GetCharacterSettings);
     this->Add("LogSettings", &CharMgrService::LogSettings);
     this->Add("GetCharacterDescription", &CharMgrService::GetCharacterDescription);
     this->Add("SetCharacterDescription", &CharMgrService::SetCharacterDescription);
@@ -384,6 +385,11 @@ PyResult CharMgrService::GetSettingsInfo(PyCallArgs& call) {
 
     res->items[ 1 ] = new PyInt( 0 );
     return res;
+}
+
+PyResult CharMgrService::GetCharacterSettings(PyCallArgs& call) {
+    sLog.Debug("CharMgrService", "GetCharacterSettings called - returning empty dict");
+    return new PyDict();
 }
 
 // this takes in the value returned from the function we return in GetSettingsInfo

--- a/src/eve-server/character/CharMgrService.cpp
+++ b/src/eve-server/character/CharMgrService.cpp
@@ -119,6 +119,7 @@ CharMgrService::CharMgrService(EVEServiceManager& mgr) :
     this->Add("GetContactList", &CharMgrService::GetContactList);
     this->Add("GetCloneTypeID", &CharMgrService::GetCloneTypeID);
     this->Add("GetHomeStation", &CharMgrService::GetHomeStation);
+    this->Add("GetHomeStationRow", &CharMgrService::GetHomeStationRow);
     this->Add("GetFactions", &CharMgrService::GetFactions);
     this->Add("SetActivityStatus", &CharMgrService::SetActivityStatus);
     this->Add("GetSettingsInfo", &CharMgrService::GetSettingsInfo);
@@ -153,7 +154,7 @@ BoundDispatcher* CharMgrService::BindObject(Client *client, PyRep* bindParameter
     //crap
     PyRep* tmp(bindParameters->Clone());
     if (!args.Decode(&tmp)) {
-        codelog(SERVICE__ERROR, "%s: Failed to decode arguments.", GetName());
+        codelog(SERVICE__ERROR, "%s: Failed to decode arguments.", this->GetName());
         return nullptr;
     }
 
@@ -284,6 +285,18 @@ PyResult CharMgrService::GetHomeStation(PyCallArgs& call)
 		return PyStatic.NewNone();
 	}
     return new PyInt(stationID);
+}
+
+PyResult CharMgrService::GetHomeStationRow(PyCallArgs& call)
+{
+    sLog.Debug("CharMgrService", "GetHomeStationRow called for Char %u (%s)", call.client->GetCharacterID(), call.client->GetName());
+    PyRep* result = CharacterDB::GetHomeStationRow(call.client->GetCharacterID());
+    if (result == nullptr) {
+        sLog.Error( "CharMgrService", "Could't get the home station row for Char %u", call.client->GetCharacterID() );
+        return PyStatic.NewNone();
+    }
+    sLog.Debug("CharMgrService", "GetHomeStationRow returned successfully for Char %u", call.client->GetCharacterID());
+    return result;
 }
 
 PyResult CharMgrService::SetActivityStatus(PyCallArgs& call, PyInt* afk, PyInt* secondsAFK) {

--- a/src/eve-server/character/CharMgrService.h
+++ b/src/eve-server/character/CharMgrService.h
@@ -57,6 +57,7 @@ protected:
     PyResult GetFactions(PyCallArgs& call);
     PyResult SetActivityStatus(PyCallArgs& call, PyInt* afk, PyInt* secondsAFK);
     PyResult GetSettingsInfo(PyCallArgs& call);
+    PyResult GetCharacterSettings(PyCallArgs& call);
     PyResult LogSettings(PyCallArgs& call, PyRep* settingsInfoRet);
     PyResult GetCharacterDescription(PyCallArgs& call, PyInt* characterID);
     PyResult SetCharacterDescription(PyCallArgs& call, PyWString* description);

--- a/src/eve-server/character/CharMgrService.h
+++ b/src/eve-server/character/CharMgrService.h
@@ -53,6 +53,7 @@ protected:
     PyResult GetContactList(PyCallArgs& call);
     PyResult GetCloneTypeID(PyCallArgs& call);
     PyResult GetHomeStation(PyCallArgs& call);
+    PyResult GetHomeStationRow(PyCallArgs& call);
     PyResult GetFactions(PyCallArgs& call);
     PyResult SetActivityStatus(PyCallArgs& call, PyInt* afk, PyInt* secondsAFK);
     PyResult GetSettingsInfo(PyCallArgs& call);

--- a/src/eve-server/character/CharUnboundMgrService.cpp
+++ b/src/eve-server/character/CharUnboundMgrService.cpp
@@ -149,8 +149,8 @@ PyResult CharUnboundMgrService::GetCharacterSelectionData(PyCallArgs &call) {
     userDetailsDict->SetItemString("logonCount", new PyLong(row.GetUInt(2)));
     userDetailsDict->SetItemString("lastLogin", new PyLong(row.GetUInt(3)));
     userDetailsDict->SetItemString("subscriptionEndTime", new PyLong(0));
-    userDetailsDict->SetItemString("maxCharacterSlots", new PyLong(5));
-    userDetailsDict->SetItemString("characterSlots", new PyLong(5));
+    userDetailsDict->SetItemString("maxCharacterSlots", new PyLong(3));
+    userDetailsDict->SetItemString("characterSlots", new PyLong(3));
     userDetailsDict->SetItemString("userName", new PyString(row.GetText(1)));
     userDetailsDict->SetItemString("creationDate", new PyLong(0));
     

--- a/src/eve-server/character/CharUnboundMgrService.cpp
+++ b/src/eve-server/character/CharUnboundMgrService.cpp
@@ -143,14 +143,19 @@ PyResult CharUnboundMgrService::GetCharacterSelectionData(PyCallArgs &call) {
         return nullptr;
     }
     
-    PyDict* userDetails = new PyDict();
-    userDetails->SetItem(new PyString("accountID"), new PyLong(row.GetUInt(0)));
-    userDetails->SetItem(new PyString("accountName"), new PyString(row.GetText(1)));
-    userDetails->SetItem(new PyString("logonCount"), new PyLong(row.GetUInt(2)));
-    userDetails->SetItem(new PyString("lastLogin"), new PyLong(row.GetUInt(3)));
+    PyDict* userDetailsDict = new PyDict();
+    userDetailsDict->SetItemString("accountID", new PyLong(row.GetUInt(0)));
+    userDetailsDict->SetItemString("accountName", new PyString(row.GetText(1)));
+    userDetailsDict->SetItemString("logonCount", new PyLong(row.GetUInt(2)));
+    userDetailsDict->SetItemString("lastLogin", new PyLong(row.GetUInt(3)));
+    userDetailsDict->SetItemString("subscriptionEndTime", new PyLong(0));
+    userDetailsDict->SetItemString("maxCharacterSlots", new PyLong(5));
+    userDetailsDict->SetItemString("characterSlots", new PyLong(5));
+    userDetailsDict->SetItemString("userName", new PyString(row.GetText(1)));
+    userDetailsDict->SetItemString("creationDate", new PyLong(0));
     
     PyTuple* userDetailsTuple = new PyTuple(1);
-    userDetailsTuple->SetItem(0, userDetails);
+    userDetailsTuple->SetItem(0, new PyObject("util.KeyVal", userDetailsDict));
     
     PyTuple* trainingDetails = new PyTuple(0);
     
@@ -225,6 +230,9 @@ PyResult CharUnboundMgrService::CreateCharacterWithDoll(PyCallArgs &call, PyRep*
 
     Client* pClient = call.client;
     pClient->CreateChar(true);
+
+    // mark that we have received the portrait
+    pClient->SetPicRec(true);
 
     if (!pClient->RecPic())
         pClient->SendInfoModalMsg("The Portrait for this character was not received.  Your character will still be created, but the server will not have their picture.");

--- a/src/eve-server/character/CharUnboundMgrService.cpp
+++ b/src/eve-server/character/CharUnboundMgrService.cpp
@@ -45,6 +45,7 @@ CharUnboundMgrService::CharUnboundMgrService(EVEServiceManager& mgr) :
     this->Add("GetCharacterToSelect", &CharUnboundMgrService::GetCharacterToSelect);
     this->Add("GetCharactersToSelect", &CharUnboundMgrService::GetCharactersToSelect);
     this->Add("GetCharacterInfo", &CharUnboundMgrService::GetCharacterInfo);
+    this->Add("GetCharacterSelectionData", &CharUnboundMgrService::GetCharacterSelectionData);
     this->Add("IsUserReceivingCharacter", &CharUnboundMgrService::IsUserReceivingCharacter);
     this->Add("DeleteCharacter", &CharUnboundMgrService::DeleteCharacter);
     this->Add("PrepareCharacterForDelete", &CharUnboundMgrService::PrepareCharacterForDelete);
@@ -55,9 +56,22 @@ CharUnboundMgrService::CharUnboundMgrService(EVEServiceManager& mgr) :
     this->Add("CreateCharacterWithDoll", &CharUnboundMgrService::CreateCharacterWithDoll);
 }
 
-PyResult CharUnboundMgrService::ValidateNameEx(PyCallArgs &call, PyRep* name)
+PyResult CharUnboundMgrService::ValidateNameEx(PyCallArgs &call, PyRep* name, PyInt* loadDungeon)
 {
-    return CharacterDB::ValidateCharNameRep(PyRep::StringContent(name));
+    std::string nameStr = PyRep::StringContent(name);
+    _log(CLIENT__MESSAGE, "ValidateNameEx: name='%s', length=%zu", nameStr.c_str(), nameStr.length());
+    
+    PyRep* result = CharacterDB::ValidateCharNameRep(nameStr);
+    if (result != nullptr) {
+        _log(CLIENT__MESSAGE, "ValidateNameEx: result type=%s", result->TypeString());
+        if (result->IsInt()) {
+            _log(CLIENT__MESSAGE, "ValidateNameEx: result value=%d", result->AsInt()->value());
+        }
+    } else {
+        _log(CLIENT__MESSAGE, "ValidateNameEx: result is nullptr");
+    }
+    
+    return result;
 }
 
 PyResult CharUnboundMgrService::GetCharacterToSelect(PyCallArgs &call, PyInt* characterID)
@@ -106,6 +120,55 @@ PyResult CharUnboundMgrService::GetCharacterInfo(PyCallArgs &call) {
     return nullptr;
 }
 
+PyResult CharUnboundMgrService::GetCharacterSelectionData(PyCallArgs &call) {
+    uint32 accountID = call.client->GetUserID();
+    
+    DBQueryResult res;
+    if (!sDatabase.RunQuery(res,
+        "SELECT "
+        "  accountID, "
+        "  accountName, "
+        "  logonCount, "
+        "  lastLogin "
+        "FROM account "
+        "WHERE accountID=%u", accountID))
+    {
+        codelog(DATABASE__ERROR, "Error in query: %s", res.error.c_str());
+        return nullptr;
+    }
+    
+    DBResultRow row;
+    if (!res.GetRow(row)) {
+        _log(CLIENT__ERROR, "No account found for accountID %u", accountID);
+        return nullptr;
+    }
+    
+    PyDict* userDetails = new PyDict();
+    userDetails->SetItem(new PyString("accountID"), new PyLong(row.GetUInt(0)));
+    userDetails->SetItem(new PyString("accountName"), new PyString(row.GetText(1)));
+    userDetails->SetItem(new PyString("logonCount"), new PyLong(row.GetUInt(2)));
+    userDetails->SetItem(new PyString("lastLogin"), new PyLong(row.GetUInt(3)));
+    
+    PyTuple* userDetailsTuple = new PyTuple(1);
+    userDetailsTuple->SetItem(0, userDetails);
+    
+    PyTuple* trainingDetails = new PyTuple(0);
+    
+    PyRep* characterDetails = CharacterDB::GetCharacterList(accountID);
+    if (characterDetails == nullptr) {
+        characterDetails = new PyList();
+    }
+    
+    PyTuple* result = new PyTuple(3);
+    result->SetItem(0, userDetailsTuple);
+    result->SetItem(1, trainingDetails);
+    result->SetItem(2, characterDetails);
+    
+    _log(CLIENT__MESSAGE, "Sending character selection data for accountID %u", accountID);
+    
+    return result;
+}
+
 PyResult CharUnboundMgrService::GetCharCreationInfo(PyCallArgs &call) {
     PyDict *result = new PyDict();
     //send all the cache hints needed for char creation.
@@ -142,14 +205,16 @@ PyResult CharUnboundMgrService::SelectCharacterID(PyCallArgs &call, PyInt* chara
 PyResult CharUnboundMgrService::CreateCharacterWithDoll(PyCallArgs &call, PyRep* characterName, PyInt* bloodlineID, PyInt* genderID, PyInt* ancestryID, PyObject* characterInfo, PyObject* portraitInfo, PyInt* schoolID) {
     // charID = sm.RemoteSvc('charUnboundMgr').CreateCharacterWithDoll(charactername, bloodlineID, genderID, ancestryID, charInfo, portraitInfo, schoolID)
     // ensure the PyObject* is an util.KeyVal, this might benefit from some helper methods instead of directly using the PyObject
-    if (characterInfo->type()->content() != "util.KeyVal" || characterInfo->arguments()->IsDict() == false) {
-        codelog(SERVICE__ERROR, "%s: Failed to decode characterInfo", GetName());
+    std::string charInfoType = characterInfo->type()->content();
+    if ((charInfoType != "util.KeyVal" && charInfoType != "utillib.KeyVal") || characterInfo->arguments()->IsDict() == false) {
+        codelog(SERVICE__ERROR, "%s: Failed to decode characterInfo (type=%s)", GetName(), charInfoType.c_str());
         return PyStatic.NewZero();
     }
 
     // ensure the PyObject* is an util.KeyVal, this might benefit from some helper methods instead of directly using the PyObject
-    if (portraitInfo->type()->content() != "util.KeyVal" || portraitInfo->arguments()->IsDict() == false) {
-        codelog(SERVICE__ERROR, "%s: Failed to decode portraitInfo", GetName());
+    std::string portraitInfoType = portraitInfo->type()->content();
+    if ((portraitInfoType != "util.KeyVal" && portraitInfoType != "utillib.KeyVal") || portraitInfo->arguments()->IsDict() == false) {
+        codelog(SERVICE__ERROR, "%s: Failed to decode portraitInfo (type=%s)", GetName(), portraitInfoType.c_str());
         return PyStatic.NewZero();
     }
 

--- a/src/eve-server/character/CharUnboundMgrService.h
+++ b/src/eve-server/character/CharUnboundMgrService.h
@@ -78,6 +78,17 @@ private:
     PyResult GetCharacterInfo(PyCallArgs& call);
 
     /**
+     * \brief Get character selection data for the character selection screen
+     *
+     * Returns user details, training details, and character details needed for character selection.
+     * This is the main method called by the client when showing the character selection screen.
+     *
+     * @param[in] call empty
+     * @return PyResult tuple of (userDetails, trainingDetails, characterDetails)
+     */
+    PyResult GetCharacterSelectionData(PyCallArgs& call);
+
+    /**
      * \brief Client check if this account is currently receiving a character from an character transfer
      *
      * Since we have no infrastructure for character transfer, this is not implemented and will always return false
@@ -94,12 +105,14 @@ private:
     /**
      * \brief Client check to see if a name may be used for a new character
      *
-     * Validates a name by checking if it confirms to naming standards and if it doesn't exist. No idea as to how this differs from ValidateName.
+     * Validates a name by checking if it confirms to naming standards and if it doesn't exist.
      *
-     * @param[in] call name to check
+     * @param[in] call call arguments
+     * @param[in] name name to check
+     * @param[in] loadDungeon load dungeon flag (unused)
      * @return PyResult true if the name may be used
      */
-    PyResult ValidateNameEx(PyCallArgs& call, PyRep* name);
+    PyResult ValidateNameEx(PyCallArgs& call, PyRep* name, PyInt* loadDungeon = nullptr);
 
     PyResult GetCharCreationInfo(PyCallArgs& call);
     PyResult GetCharNewExtraCreationInfo(PyCallArgs& call);

--- a/src/eve-server/character/Character.cpp
+++ b/src/eve-server/character/Character.cpp
@@ -423,6 +423,20 @@ void Character::SetDescription(const char *newDescription) {
     SaveCharacter();
 }
 
+void Character::SetClient(Client* pClient) {
+    m_pClient = pClient;
+    
+    if (m_pClient != nullptr) {
+        Rsp_CommonGetInfo_Entry entry;
+        if (Populate(entry)) {
+            PyTuple* tuple = new PyTuple(2);
+            tuple->SetItem(0, new PyInt(m_itemID));
+            tuple->SetItem(1, new PyObject("util.KeyVal", entry.Encode()));
+            m_pClient->SendNotification("OnGodmaPrimeItem", "clientID", tuple);
+        }
+    }
+}
+
 void Character::JoinCorporation(const CorpData &data) {
     // Add new employment history record    -allan  25Mar14   update 20Jan15   update again 23May19
     CharacterDB::AddEmployment(m_itemID, data.corporationID, m_corpData.corporationID);

--- a/src/eve-server/character/Character.h
+++ b/src/eve-server/character/Character.h
@@ -229,7 +229,7 @@ public:
     void            SetFleetData(CharFleetData& fleet);
     uint32          PickAlternateShip(uint32 locationID);
 
-    void            SetClient(Client* pClient)          { m_pClient = pClient; }
+    void            SetClient(Client* pClient);
     Client*         GetClient()                         { return m_pClient; }
 
     void            AddItem(InventoryItemRef item);

--- a/src/eve-server/character/CharacterDB.cpp
+++ b/src/eve-server/character/CharacterDB.cpp
@@ -250,43 +250,66 @@ PyRep* CharacterDB::ValidateCharNameRep(std::string name)
              */
     // *name  is sent from client WITHOUT leading space, if there is one, and will not allow more than one space.
 
-    if (name.empty())
+    _log(CLIENT__MESSAGE, "ValidateCharNameRep: name='%s', length=%zu", name.c_str(), name.length());
+
+    if (name.empty()) {
+        _log(CLIENT__MESSAGE, "ValidateCharNameRep: empty name");
         return new PyInt(-1);
-    if (name.length() < 3)
+    }
+    if (name.length() < 3) {
+        _log(CLIENT__MESSAGE, "ValidateCharNameRep: name too short (length=%zu)", name.length());
         return new PyInt(-1);
-    if (name.length() > 37)    //client caps at 24
+    }
+    if (name.length() > 37) {
+        _log(CLIENT__MESSAGE, "ValidateCharNameRep: name too long (length=%zu)", name.length());
         return new PyInt(-2);
+    }
 
-    if (!sDatabase.IsSafeString(name.c_str()))
+    if (!sDatabase.IsSafeString(name.c_str())) {
+        _log(CLIENT__MESSAGE, "ValidateCharNameRep: IsSafeString failed");
         return new PyInt(-5);
+    }
 
-    for (const auto cur : badWords)
-        if (EvE::icontains(name, cur))
+    for (const auto cur : badWords) {
+        if (EvE::icontains(name, cur)) {
+            _log(CLIENT__MESSAGE, "ValidateCharNameRep: badWords matched '%s'", cur.c_str());
             return new PyInt(-5);
+        }
+    }
 
-    for (const auto cur : badChars)
-        if (EvE::icontains(name, cur))
+    for (const auto cur : badChars) {
+        if (EvE::icontains(name, cur)) {
+            _log(CLIENT__MESSAGE, "ValidateCharNameRep: badChars matched '%s'", cur.c_str());
             return new PyInt(-5);
+        }
+    }
 
     // check for consecutive spaces
-    if (EvE::icontains(name, "  "))
+    if (EvE::icontains(name, "  ")) {
+        _log(CLIENT__MESSAGE, "ValidateCharNameRep: consecutive spaces");
         return new PyInt(-7);
+    }
 
     // check for multiple spaces
     int found = name.find(" ");
     if (found != name.npos) {
         found = name.find(" ", found + 1, 1);
-        if (found != name.npos)
+        if (found != name.npos) {
+            _log(CLIENT__MESSAGE, "ValidateCharNameRep: multiple spaces");
             return new PyInt(-6);
+        }
     }
 
     std::string eName;
     sDatabase.DoEscapeString(eName, name.c_str());
     DBQueryResult res;
     sDatabase.RunQuery(res, "SELECT characterID FROM chrCharacters WHERE characterName LIKE '%s' ", eName.c_str() );
-    if (res.GetRowCount() > 0)  // name exists
+    if (res.GetRowCount() > 0) {
+        _log(CLIENT__MESSAGE, "ValidateCharNameRep: name already exists");
         return new PyInt(-101);
+    }
 
+    _log(CLIENT__MESSAGE, "ValidateCharNameRep: name is valid");
     /* if we got here the name is "new" */
     return PyStatic.NewOne();
 }

--- a/src/eve-server/character/CharacterDB.cpp
+++ b/src/eve-server/character/CharacterDB.cpp
@@ -252,7 +252,7 @@ PyRep *CharacterDB::GetCharacterList(uint32 accountID) {
         "  c.shipID,"
         "  c.capsuleID,"
         "  c.age,"
-        "  c.paperDollState,"
+        "  c.paperDollState AS paperdollState,"
         "  c.skillPoints,"
         "  c.skillQueueEndTime,"
         "  c.logonDateTime,"
@@ -275,7 +275,7 @@ PyRep *CharacterDB::GetCharacterList(uint32 accountID) {
         "  c.careerID,"
         "  c.schoolID,"
         "  c.careerSpecialityID,"
-        "  0 AS shipTypeID,"
+        "  (SELECT typeID FROM entity WHERE itemID = c.shipID) AS shipTypeID,"
         "  0 AS unreadMailCount,"
         "  0 AS unprocessedNotifications,"
         "  '' AS petitionMessage,"
@@ -303,7 +303,11 @@ PyRep *CharacterDB::GetCharacterList(uint32 accountID) {
         PyDict* dict = new PyDict();
         dict->SetItemString("characterID", new PyLong(row.GetUInt(0)));
         dict->SetItemString("characterName", new PyString(row.GetText(1)));
-        dict->SetItemString("deletePrepareDateTime", new PyLong(row.GetUInt(2)));
+        if (row.IsNull(2) || row.GetUInt(2) == 0) {
+            dict->SetItemString("deletePrepareDateTime", new PyNone());
+        } else {
+            dict->SetItemString("deletePrepareDateTime", new PyLong(row.GetUInt(2)));
+        }
         dict->SetItemString("gender", new PyLong(row.GetUInt(3)));
         dict->SetItemString("typeID", new PyLong(row.GetUInt(4)));
         dict->SetItemString("stationID", new PyLong(row.GetUInt(5)));
@@ -331,7 +335,7 @@ PyRep *CharacterDB::GetCharacterList(uint32 accountID) {
         dict->SetItemString("shipID", new PyLong(row.GetUInt(27)));
         dict->SetItemString("capsuleID", new PyLong(row.GetUInt(28)));
         dict->SetItemString("age", new PyLong(row.GetUInt(29)));
-        dict->SetItemString("paperDollState", new PyLong(row.GetUInt(30)));
+        dict->SetItemString("paperdollState", new PyLong(row.GetUInt(30)));
         dict->SetItemString("skillPoints", new PyLong(row.GetUInt(31)));
         dict->SetItemString("skillQueueEndTime", new PyLong(row.GetUInt(32)));
         dict->SetItemString("logonDateTime", new PyLong(row.GetUInt(33)));

--- a/src/eve-server/character/CharacterDB.cpp
+++ b/src/eve-server/character/CharacterDB.cpp
@@ -1275,7 +1275,7 @@ PyRep* CharacterDB::GetHomeStationRow(uint32 characterID) {
     if (!sDatabase.RunQuery(res,
         "SELECT e.locationID, s.solarSystemID, s.stationTypeID "
         "FROM entity e "
-        "LEFT JOIN staStations s ON e.locationID = s.stationID "
+        "LEFT JOIN stastations s ON e.locationID = s.stationID "
         "WHERE e.ownerID = %u "
         "  AND e.flag=400",
         characterID ))
@@ -1888,10 +1888,14 @@ PyRep* CharacterDB::GetSkillHistory(uint32 characterID) {
         " LIMIT 50",
         characterID )) {
         codelog(DATABASE__ERROR, "Error in query: %s", res.error.c_str());
-        return nullptr;
+        return new PyList();
     }
 
-    return DBResultToRowset(res);
+    PyRep* result = DBResultToCRowset(res);
+    if (result == nullptr) {
+        return new PyList();
+    }
+    return result;
 }
 
 void CharacterDB::UpdateSkillQueueEndTime(int64 endtime, uint32 charID) {
@@ -2100,36 +2104,31 @@ PyRep* CharacterDB::List(uint32 ownerID)
 
 PyRep* CharacterDB::ListStations(uint32 ownerID, std::ostringstream& flagIDs, bool forCorp/*false*/, bool bpOnly/*false*/)
 {
-    /** @todo check into this to see if we're querying POS modules(uk) also.
-     * if so, we'll need to revise location checks and somehow fix it so customs offices (and anything else using flagHangar)
-     *  doesnt show up, which leads to elusive "AttributeError: 'NoneType' object has no attribute 'solarSystemID'"  in client
-     *  when locationID is NOT station
-     */
     DBQueryResult res;
-    /** @todo these queries are wrong....  (location and maybe owner)*/
     if (bpOnly) {
         if (forCorp) {
-            // this is some funky shit to get correct stationID for corp bps in hangar, as their location is officeID, but we need stationID for this call
             if (!sDatabase.RunQuery(res,
-                "SELECT o.stationID, COUNT(e.itemID) as blueprintCount"
+                "SELECT o.stationID, s.solarSystemID, COUNT(e.itemID) as blueprintCount"
                 " FROM entity AS e"
                 "  LEFT JOIN invTypes USING (typeID)"
                 "  LEFT JOIN invGroups AS g USING (groupID)"
                 "  LEFT JOIN staOffices as o ON o.itemID = e.locationID"
+                "  LEFT JOIN stastations as s ON s.stationID = o.stationID"
                 " WHERE e.ownerID=%u AND e.flag IN (%s) AND g.categoryID = %u AND (e.locationID >= %u AND e.locationID <= %u)"
-                " GROUP BY locationID", ownerID, flagIDs.str().c_str(), EVEDB::invCategories::Blueprint, minOffice, maxOffice))
+                " GROUP BY o.stationID, s.solarSystemID", ownerID, flagIDs.str().c_str(), EVEDB::invCategories::Blueprint, minOffice, maxOffice))
             {
                 codelog(SERVICE__ERROR, "Error in ListStations query: %s", res.error.c_str());
                 return nullptr;
             }
         } else {
             if (!sDatabase.RunQuery(res,
-                "SELECT e.locationID AS stationID, COUNT(e.itemID) as blueprintCount"
+                "SELECT e.locationID AS stationID, s.solarSystemID, COUNT(e.itemID) as blueprintCount"
                 " FROM entity AS e"
                 "  LEFT JOIN invTypes USING (typeID)"
                 "  LEFT JOIN invGroups AS g USING (groupID)"
+                "  LEFT JOIN stastations as s ON s.stationID = e.locationID"
                 " WHERE e.ownerID=%u AND e.flag IN (%s) AND g.categoryID = %u AND e.locationID <= %u"
-                " GROUP BY locationID", ownerID, flagIDs.str().c_str(), EVEDB::invCategories::Blueprint, maxStation))
+                " GROUP BY e.locationID, s.solarSystemID", ownerID, flagIDs.str().c_str(), EVEDB::invCategories::Blueprint, maxStation))
             {
                 codelog(SERVICE__ERROR, "Error in ListStations query: %s", res.error.c_str());
                 return nullptr;
@@ -2137,22 +2136,24 @@ PyRep* CharacterDB::ListStations(uint32 ownerID, std::ostringstream& flagIDs, bo
         }
     } else {
         if (forCorp) {
-            // this is some funky shit to get correct stationID for corp bps in hangar, as their location is officeID, but we need stationID for this call
             if (!sDatabase.RunQuery(res,
-                "SELECT o.stationID, COUNT(e.itemID) as itemCount"
+                "SELECT o.stationID, s.solarSystemID, COUNT(e.itemID) as itemCount"
                 " FROM entity AS e"
                 "  LEFT JOIN staOffices as o ON o.itemID = e.locationID"
+                "  LEFT JOIN stastations as s ON s.stationID = o.stationID"
                 " WHERE e.ownerID=%u AND e.flag IN (%s) AND (e.locationID >= %u AND e.locationID <= %u)"
-                " GROUP BY locationID", ownerID, flagIDs.str().c_str(), minOffice, maxOffice))
+                " GROUP BY o.stationID, s.solarSystemID", ownerID, flagIDs.str().c_str(), minOffice, maxOffice))
             {
                 codelog(SERVICE__ERROR, "Error in ListStations query: %s", res.error.c_str());
                 return nullptr;
             }
         } else {
             if (!sDatabase.RunQuery(res,
-                "SELECT locationID AS stationID, COUNT(itemID) as itemCount"
-                " FROM entity WHERE ownerID=%u AND flag IN (%s) AND locationID <= %u"
-                " GROUP BY locationID", ownerID, flagIDs.str().c_str(), maxStation))
+                "SELECT e.locationID AS stationID, s.solarSystemID, COUNT(e.itemID) as itemCount"
+                " FROM entity AS e"
+                "  LEFT JOIN stastations as s ON s.stationID = e.locationID"
+                " WHERE e.ownerID=%u AND e.flag IN (%s) AND e.locationID <= %u"
+                " GROUP BY e.locationID, s.solarSystemID", ownerID, flagIDs.str().c_str(), maxStation))
             {
                 codelog(SERVICE__ERROR, "Error in ListStations query: %s", res.error.c_str());
                 return nullptr;

--- a/src/eve-server/character/CharacterDB.cpp
+++ b/src/eve-server/character/CharacterDB.cpp
@@ -222,19 +222,189 @@ PyRep *CharacterDB::GetCharacterList(uint32 accountID) {
     DBQueryResult res;
     if (!sDatabase.RunQuery(res,
         "SELECT"
-        "  characterID,"
-        "  characterName,"
-        "  deletePrepareDateTime,"
-        "  gender,"
-        "  typeID"
-        " FROM chrCharacters"
-        " WHERE accountID=%u", accountID))
+        "  c.characterID,"
+        "  c.characterName,"
+        "  c.deletePrepareDateTime,"
+        "  c.gender,"
+        "  c.typeID,"
+        "  c.stationID,"
+        "  c.solarSystemID,"
+        "  c.logoffDateTime AS logoffDate,"
+        "  c.corporationID,"
+        "  co.allianceID,"
+        "  c.raceID,"
+        "  c.bloodlineID,"
+        "  c.ancestryID,"
+        "  c.freeRespecs,"
+        "  c.lastRespecDateTime,"
+        "  c.nextRespecDateTime,"
+        "  c.accountID,"
+        "  c.balance,"
+        "  c.aurBalance,"
+        "  c.logonMinutes,"
+        "  c.title,"
+        "  c.description,"
+        "  c.securityRating,"
+        "  c.locationID,"
+        "  c.constellationID,"
+        "  c.regionID,"
+        "  c.createDateTime,"
+        "  c.shipID,"
+        "  c.capsuleID,"
+        "  c.age,"
+        "  c.paperDollState,"
+        "  c.skillPoints,"
+        "  c.skillQueueEndTime,"
+        "  c.logonDateTime,"
+        "  c.online,"
+        "  c.bounty,"
+        "  c.baseID,"
+        "  c.corpAccountKey,"
+        "  c.corpRole,"
+        "  c.rolesAtAll,"
+        "  c.rolesAtHQ,"
+        "  c.rolesAtBase,"
+        "  c.rolesAtOther,"
+        "  c.grantableRoles,"
+        "  c.grantableRolesAtHQ,"
+        "  c.grantableRolesAtBase,"
+        "  c.grantableRolesAtOther,"
+        "  c.titleMask,"
+        "  c.blockRoles,"
+        "  c.startDateTime,"
+        "  c.careerID,"
+        "  c.schoolID,"
+        "  c.careerSpecialityID,"
+        "  0 AS shipTypeID,"
+        "  0 AS unreadMailCount,"
+        "  0 AS unprocessedNotifications,"
+        "  '' AS petitionMessage,"
+        "  '' AS finishedSkills,"
+        "  0 AS balanceChange,"
+        "  NULL AS skillTypeID,"
+        "  NULL AS toLevel,"
+        "  NULL AS trainingStartTime,"
+        "  NULL AS trainingEndTime,"
+        "  NULL AS queueEndTime,"
+        "  NULL AS finishSP,"
+        "  NULL AS trainedSP,"
+        "  NULL AS fromSP"
+        " FROM chrCharacters AS c"
+        "  LEFT JOIN crpCorporation AS co ON c.corporationID = co.corporationID"
+        " WHERE c.accountID=%u", accountID))
     {
         codelog(DATABASE__ERROR, "Error in query: %s", res.error.c_str());
         return nullptr;
     }
 
-    return DBResultToCRowset(res);
+    PyList* list = new PyList();
+    DBResultRow row;
+    while (res.GetRow(row)) {
+        PyDict* dict = new PyDict();
+        dict->SetItemString("characterID", new PyLong(row.GetUInt(0)));
+        dict->SetItemString("characterName", new PyString(row.GetText(1)));
+        dict->SetItemString("deletePrepareDateTime", new PyLong(row.GetUInt(2)));
+        dict->SetItemString("gender", new PyLong(row.GetUInt(3)));
+        dict->SetItemString("typeID", new PyLong(row.GetUInt(4)));
+        dict->SetItemString("stationID", new PyLong(row.GetUInt(5)));
+        dict->SetItemString("solarSystemID", new PyLong(row.GetUInt(6)));
+        dict->SetItemString("logoffDate", new PyLong(row.GetUInt(7)));
+        dict->SetItemString("corporationID", new PyLong(row.GetUInt(8)));
+        dict->SetItemString("allianceID", new PyLong(row.GetUInt(9)));
+        dict->SetItemString("raceID", new PyLong(row.GetUInt(10)));
+        dict->SetItemString("bloodlineID", new PyLong(row.GetUInt(11)));
+        dict->SetItemString("ancestryID", new PyLong(row.GetUInt(12)));
+        dict->SetItemString("freeRespecs", new PyLong(row.GetUInt(13)));
+        dict->SetItemString("lastRespecDateTime", new PyLong(row.GetUInt(14)));
+        dict->SetItemString("nextRespecDateTime", new PyLong(row.GetUInt(15)));
+        dict->SetItemString("accountID", new PyLong(row.GetUInt(16)));
+        dict->SetItemString("balance", new PyFloat(row.GetFloat(17)));
+        dict->SetItemString("aurBalance", new PyFloat(row.GetFloat(18)));
+        dict->SetItemString("logonMinutes", new PyLong(row.GetUInt(19)));
+        dict->SetItemString("title", new PyString(row.GetText(20)));
+        dict->SetItemString("description", new PyString(row.GetText(21)));
+        dict->SetItemString("securityRating", new PyFloat(row.GetFloat(22)));
+        dict->SetItemString("locationID", new PyLong(row.GetUInt(23)));
+        dict->SetItemString("constellationID", new PyLong(row.GetUInt(24)));
+        dict->SetItemString("regionID", new PyLong(row.GetUInt(25)));
+        dict->SetItemString("createDateTime", new PyLong(row.GetUInt(26)));
+        dict->SetItemString("shipID", new PyLong(row.GetUInt(27)));
+        dict->SetItemString("capsuleID", new PyLong(row.GetUInt(28)));
+        dict->SetItemString("age", new PyLong(row.GetUInt(29)));
+        dict->SetItemString("paperDollState", new PyLong(row.GetUInt(30)));
+        dict->SetItemString("skillPoints", new PyLong(row.GetUInt(31)));
+        dict->SetItemString("skillQueueEndTime", new PyLong(row.GetUInt(32)));
+        dict->SetItemString("logonDateTime", new PyLong(row.GetUInt(33)));
+        dict->SetItemString("online", new PyLong(row.GetUInt(34)));
+        dict->SetItemString("bounty", new PyFloat(row.GetFloat(35)));
+        dict->SetItemString("baseID", new PyLong(row.GetUInt(36)));
+        dict->SetItemString("corpAccountKey", new PyLong(row.GetUInt(37)));
+        dict->SetItemString("corpRole", new PyLong(row.GetUInt(38)));
+        dict->SetItemString("rolesAtAll", new PyLong(row.GetUInt(39)));
+        dict->SetItemString("rolesAtHQ", new PyLong(row.GetUInt(40)));
+        dict->SetItemString("rolesAtBase", new PyLong(row.GetUInt(41)));
+        dict->SetItemString("rolesAtOther", new PyLong(row.GetUInt(42)));
+        dict->SetItemString("grantableRoles", new PyLong(row.GetUInt(43)));
+        dict->SetItemString("grantableRolesAtHQ", new PyLong(row.GetUInt(44)));
+        dict->SetItemString("grantableRolesAtBase", new PyLong(row.GetUInt(45)));
+        dict->SetItemString("grantableRolesAtOther", new PyLong(row.GetUInt(46)));
+        dict->SetItemString("titleMask", new PyLong(row.GetUInt(47)));
+        dict->SetItemString("blockRoles", new PyLong(row.GetUInt(48)));
+        dict->SetItemString("startDateTime", new PyLong(row.GetUInt(49)));
+        dict->SetItemString("careerID", new PyLong(row.GetUInt(50)));
+        dict->SetItemString("schoolID", new PyLong(row.GetUInt(51)));
+        dict->SetItemString("careerSpecialityID", new PyLong(row.GetUInt(52)));
+        dict->SetItemString("shipTypeID", new PyLong(row.GetUInt(53)));
+        dict->SetItemString("unreadMailCount", new PyLong(row.GetUInt(54)));
+        dict->SetItemString("unprocessedNotifications", new PyLong(row.GetUInt(55)));
+        dict->SetItemString("petitionMessage", new PyString(row.GetText(56)));
+        dict->SetItemString("finishedSkills", new PyString(row.GetText(57)));
+        dict->SetItemString("balanceChange", new PyFloat(row.GetFloat(58)));
+        if (row.IsNull(59)) {
+            dict->SetItemString("skillTypeID", new PyNone());
+        } else {
+            dict->SetItemString("skillTypeID", new PyLong(row.GetUInt(59)));
+        }
+        if (row.IsNull(60)) {
+            dict->SetItemString("toLevel", new PyNone());
+        } else {
+            dict->SetItemString("toLevel", new PyLong(row.GetUInt(60)));
+        }
+        if (row.IsNull(61)) {
+            dict->SetItemString("trainingStartTime", new PyNone());
+        } else {
+            dict->SetItemString("trainingStartTime", new PyLong(row.GetUInt(61)));
+        }
+        if (row.IsNull(62)) {
+            dict->SetItemString("trainingEndTime", new PyNone());
+        } else {
+            dict->SetItemString("trainingEndTime", new PyLong(row.GetUInt(62)));
+        }
+        if (row.IsNull(63)) {
+            dict->SetItemString("queueEndTime", new PyNone());
+        } else {
+            dict->SetItemString("queueEndTime", new PyLong(row.GetUInt(63)));
+        }
+        if (row.IsNull(64)) {
+            dict->SetItemString("finishSP", new PyNone());
+        } else {
+            dict->SetItemString("finishSP", new PyLong(row.GetUInt(64)));
+        }
+        if (row.IsNull(65)) {
+            dict->SetItemString("trainedSP", new PyNone());
+        } else {
+            dict->SetItemString("trainedSP", new PyLong(row.GetUInt(65)));
+        }
+        if (row.IsNull(66)) {
+            dict->SetItemString("fromSP", new PyNone());
+        } else {
+            dict->SetItemString("fromSP", new PyLong(row.GetUInt(66)));
+        }
+        
+        list->AddItem(new PyObject("util.KeyVal", dict));
+    }
+
+    return list;
 }
 
 PyRep* CharacterDB::ValidateCharNameRep(std::string name)
@@ -1094,6 +1264,43 @@ bool CharacterDB::GetCharHomeStation(uint32 characterID, uint32 &stationID) {
     if (res.GetRow(row))
         stationID = row.GetUInt(0);
 	return true;
+}
+
+PyRep* CharacterDB::GetHomeStationRow(uint32 characterID) {
+    DBQueryResult res;
+    if (!sDatabase.RunQuery(res,
+        "SELECT e.locationID, s.solarSystemID, s.stationTypeID "
+        "FROM entity e "
+        "LEFT JOIN staStations s ON e.locationID = s.stationID "
+        "WHERE e.ownerID = %u "
+        "  AND e.flag=400",
+        characterID ))
+    {
+        _log(CHARACTER__ERROR, "Could't get home station row for char %u - query failed: %s", characterID, res.error.c_str());
+        return nullptr;
+    }
+
+    _log(CHARACTER__MESSAGE, "GetHomeStationRow: char %u returned %u rows", characterID, res.GetRowCount());
+
+    DBResultRow row;
+    if (!res.GetRow(row)) {
+        _log(CHARACTER__ERROR, "No home station found for char %u", characterID );
+        return nullptr;
+    }
+
+    uint32 stationID = row.GetUInt(0);
+    uint32 solarSystemID = row.GetUInt(1);
+    uint32 stationTypeID = row.GetUInt(2);
+
+    _log(CHARACTER__MESSAGE, "GetHomeStationRow: char %u - stationID=%u, solarSystemID=%u, stationTypeID=%u", characterID, stationID, solarSystemID, stationTypeID);
+
+    PyDict* result = new PyDict();
+    result->SetItemString("stationID", new PyInt(stationID));
+    result->SetItemString("solarSystemID", new PyInt(solarSystemID));
+    result->SetItemString("stationTypeID", new PyInt(stationTypeID));
+
+    PyObject* keyVal = new PyObject("util.KeyVal", result);
+    return keyVal;
 }
 
 //replace all the typeID of the character's clones

--- a/src/eve-server/character/CharacterDB.h
+++ b/src/eve-server/character/CharacterDB.h
@@ -213,7 +213,7 @@ public:
     bool        SaveSkillQueue(uint32 charID, SkillQueue &queue);
     bool        SavePausedSkillQueue(uint32 charID, SkillQueue &queue);
     void        SaveSkillHistory(uint16 eventID, double logDate, uint32 characterID, uint32 skillTypeID, uint8 skillLevel, uint32 absolutePoints);
-    PyRep*      GetSkillHistory(uint32 charID);
+    PyRep*      GetSkillHistory(uint32 characterID);
     void        UpdateSkillQueueEndTime(int64 endtime, uint32 charID);
 
     void        SetLogInTime(uint32 charID);

--- a/src/eve-server/character/CharacterDB.h
+++ b/src/eve-server/character/CharacterDB.h
@@ -103,6 +103,7 @@ public:
     static bool GetCharacterData(uint32 characterID, CharacterData &into);
     static void GetCharacterDataMap(uint32 charID, std::map<std::string, int64> &characterDataMap);
     static bool GetCharHomeStation(uint32 charID, uint32 &stationID);
+    static PyRep* GetHomeStationRow(uint32 charID);
     //if you want to get the typeID of the clone use GetActiveCloneType
     static bool GetActiveCloneID(uint32 charID, uint32 &itemID);
     static PyRep *GetInfoWindowDataForChar(uint32 charID);

--- a/src/eve-server/character/SkillMgrService.cpp
+++ b/src/eve-server/character/SkillMgrService.cpp
@@ -62,6 +62,7 @@ SkillMgrBound::SkillMgrBound(EVEServiceManager &mgr, SkillMgrService& parent, Ch
     this->Add("GetRespecInfo", &SkillMgrBound::GetRespecInfo);
     this->Add("RespecCharacter", &SkillMgrBound::RespecCharacter);
     this->Add("GetCharacterAttributeModifiers", &SkillMgrBound::GetCharacterAttributeModifiers);
+    this->Add("GetRequiredSkills", &SkillMgrBound::GetRequiredSkills);
 }
 
 PyResult SkillMgrBound::GetRespecInfo(PyCallArgs& call) {
@@ -277,4 +278,53 @@ PyResult SkillMgrBound::RemoveImplantFromCharacter(PyCallArgs& call, PyInt* item
 {
     //sends itemid
     return nullptr;
+}
+
+PyResult SkillMgrBound::GetRequiredSkills(PyCallArgs& call, PyInt* typeID)
+{
+    // Get required skills for a given typeID
+    // Returns a dictionary of {skillTypeID: requiredLevel}
+    PyDict* result = new PyDict();
+    
+    // Query skill requirement attributes for this type
+    // Attribute ID 182 = requiredSkill1 (stores the skill type ID)
+    // Attribute ID 277 = requiredSkill1Level (stores the required skill level)
+    // Attribute ID 183 = requiredSkill2 (stores the skill type ID)
+    // Attribute ID 278 = requiredSkill2Level (stores the required skill level)
+    // Attribute ID 184 = requiredSkill3 (stores the skill type ID)
+    // Attribute ID 279 = requiredSkill3Level (stores the required skill level)
+    // Attribute ID 1285 = requiredSkill4 (stores the skill type ID)
+    // Attribute ID 1286 = requiredSkill4Level (stores the required skill level)
+    // Attribute ID 1287 = requiredSkill5 (stores the skill type ID)
+    // Attribute ID 1288 = requiredSkill5Level (stores the required skill level)
+    
+    DBQueryResult res;
+    if (!sDatabase.RunQuery(res,
+        "SELECT"
+        "   d1.attributeID as skillAttrID,"
+        "   d1.valueInt as skillTypeID,"
+        "   d2.valueInt as skillLevel"
+        " FROM dgmTypeAttributes d1"
+        " LEFT JOIN dgmTypeAttributes d2 ON d1.typeID = d2.typeID"
+        "   AND d2.attributeID = d1.attributeID + 95"  // 277 = 182 + 95, 278 = 183 + 95, etc.
+        " WHERE d1.typeID = %u"
+        " AND d1.attributeID IN (182, 183, 184, 1285, 1287)"
+        " AND d1.valueInt IS NOT NULL"
+        " AND d1.valueInt != 0",
+        typeID->value())) {
+        codelog(DATABASE__ERROR, "Error in GetRequiredSkills query: %s", res.error.c_str());
+        return result;
+    }
+    
+    DBResultRow row;
+    while (res.GetRow(row)) {
+        uint32 skillTypeID = row.GetUInt(1);
+        uint32 skillLevel = row.IsNull(2) ? 1 : row.GetUInt(2);
+        // Ensure skillTypeID is not 0 or invalid
+        if (skillTypeID > 0) {
+            result->SetItem(new PyInt(skillTypeID), new PyInt(skillLevel));
+        }
+    }
+    
+    return result;
 }

--- a/src/eve-server/character/SkillMgrService.h
+++ b/src/eve-server/character/SkillMgrService.h
@@ -68,6 +68,7 @@ protected:
     PyResult GetCharacterAttributeModifiers(PyCallArgs& call, PyInt* attr);
     PyResult CharAddImplant(PyCallArgs& call, PyInt* itemID);
     PyResult RemoveImplantFromCharacter(PyCallArgs& call, PyInt* itemID);
+    PyResult GetRequiredSkills(PyCallArgs& call, PyInt* typeID);
 };
 
 #endif

--- a/src/eve-server/config/ConfigDB.cpp
+++ b/src/eve-server/config/ConfigDB.cpp
@@ -500,6 +500,7 @@ PyRep *ConfigDB::GetDynamicCelestials(uint32 solarSystemID) {
                   ["z" => <430524948480> [R8]]
                   ["celestialIndex" => <6> [UI1]]
                   ["orbitIndex" => <0> [UI1]]
+                  ["celestialNameID" => <0> [I4]]
                   */
 
     DBQueryResult result;
@@ -510,11 +511,12 @@ PyRep *ConfigDB::GetDynamicCelestials(uint32 solarSystemID) {
         "   itemID,"
         "   itemName,"
         "   solarSystemID AS locationID,"
-        "   IFNULL(orbitID, False) AS orbitID,"
+        "   IFNULL(orbitID, 0) AS orbitID,"
         "   0 AS connector,"     //this is connector field....have only seen 0 in server packets.
-        "   x, y, z"
-        //"   celestialIndex,"    //  this index denotes which planet this item orbits (PLANET #....NOT moon #)
-        //"   orbitIndex"         //  this index denotes which asteroid belt this item belongs to
+        "   x, y, z,"
+        "   IFNULL(celestialIndex, 0) AS celestialIndex,"
+        "   IFNULL(orbitIndex, 0) AS orbitIndex,"
+        "   IFNULL(itemNameID, 0) AS celestialNameID"
         " FROM mapDenormalize"
         " WHERE solarSystemID = %u"
         " AND groupID = %d"

--- a/src/eve-server/config/ConfigService.cpp
+++ b/src/eve-server/config/ConfigService.cpp
@@ -48,6 +48,7 @@ ConfigService::ConfigService() :
     this->Add("GetDynamicCelestials", &ConfigService::GetDynamicCelestials);
     this->Add("GetMapLandmarks", &ConfigService::GetMapLandmarks);
     this->Add("SetMapLandmarks", &ConfigService::SetMapLandmarks);
+    this->Add("GetAverageMarketPrices", &ConfigService::GetAverageMarketPrices);
 }
 
 /** @todo put these next two in static data to avoid db hits  */
@@ -272,5 +273,34 @@ PyResult ConfigService::SetMapLandmarks(PyCallArgs &call, PyList* landmarkData) 
     call.Dump(CACHE__DUMP);
 
     return nullptr;
+}
+
+PyResult ConfigService::GetAverageMarketPrices(PyCallArgs &call) {
+    /**
+     * Returns a dictionary of typeID to average market price
+     * This is used by the client to display estimated item values
+     */
+    _log(CACHE__DUMP,  "ConfigService::Handle_GetAverageMarketPrices()");
+    call.Dump(CACHE__DUMP);
+
+    PyDict* result = new PyDict();
+    
+    DBQueryResult res;
+    if (!sDatabase.RunQuery(res,
+        "SELECT typeID, basePrice"
+        " FROM invtypes"
+        " WHERE basePrice > 0")) {
+        codelog(DATABASE__ERROR, "Error in GetAverageMarketPrices query: %s", res.error.c_str());
+        return result;
+    }
+    
+    DBResultRow row;
+    while (res.GetRow(row)) {
+        uint32 typeID = row.GetUInt(0);
+        double basePrice = row.GetDouble(1);
+        result->SetItem(new PyInt(typeID), new PyFloat(basePrice));
+    }
+    
+    return result;
 }
 

--- a/src/eve-server/config/ConfigService.h
+++ b/src/eve-server/config/ConfigService.h
@@ -56,6 +56,7 @@ protected:
     PyResult GetCelestialStatistic(PyCallArgs& call, PyInt* celestialID);
     PyResult GetDynamicCelestials(PyCallArgs& call, PyInt* locationID);
     PyResult SetMapLandmarks(PyCallArgs& call, PyList* landmarkData);
+    PyResult GetAverageMarketPrices(PyCallArgs& call);
 };
 
 #endif

--- a/src/eve-server/corporation/CorpStationMgr.cpp
+++ b/src/eve-server/corporation/CorpStationMgr.cpp
@@ -61,7 +61,7 @@ CorpStationMgr::CorpStationMgr(EVEServiceManager& mgr) :
 
 BoundDispatcher* CorpStationMgr::BindObject(Client *client, PyRep* bindParameters) {
     if (!bindParameters->IsInt()) {
-        codelog(SERVICE__ERROR, "%s Service: invalid bind argument type %s", GetName().c_str(), bindParameters->TypeString());
+        codelog(SERVICE__ERROR, "%s Service: invalid bind argument type %s", this->GetName().c_str(), bindParameters->TypeString());
         return nullptr;
     }
 

--- a/src/eve-server/corporation/LPStore.cpp
+++ b/src/eve-server/corporation/LPStore.cpp
@@ -33,6 +33,11 @@ LPStore::LPStore() :
 {
     this->Add("AcceptOffer", &LPStore::AcceptOffer);
     this->Add("GetAvailableOffers", &LPStore::GetAvailableOffers);
+    this->Add("GetAvailableOffersFromCorp", &LPStore::GetAvailableOffersFromCorp);
+    this->Add("GetLPForCharacterCorp", &LPStore::GetLPForCharacterCorp);
+    this->Add("GetLPExchangeRates", &LPStore::GetLPExchangeRates);
+    this->Add("ExchangeConcordLP", &LPStore::ExchangeConcordLP);
+    this->Add("TakeOffer", &LPStore::TakeOffer);
 
 }
 
@@ -55,5 +60,56 @@ PyResult LPStore::GetAvailableOffers(PyCallArgs& call) {
 
   call.Dump(SERVICE__CALL_DUMP);
     return new PyList;
+}
+
+PyResult LPStore::GetAvailableOffersFromCorp(PyCallArgs& call, PyInt* corpID) {
+  /**
+            self.cache.offers = sm.RemoteSvc('LPSvc').GetAvailableOffersFromCorp(self.cache.corpID)
+            */
+  sLog.White( "LPStore::GetAvailableOffersFromCorp()", "size=%lu", call.tuple->size());
+
+  call.Dump(SERVICE__CALL_DUMP);
+    return new PyList;
+}
+
+PyResult LPStore::GetLPForCharacterCorp(PyCallArgs& call, PyInt* corpID) {
+  /**
+            self.cache.lps = sm.RemoteSvc('LPSvc').GetLPForCharacterCorp(corpID)
+            */
+  sLog.White( "LPStore::GetLPForCharacterCorp()", "size=%lu", call.tuple->size());
+
+  call.Dump(SERVICE__CALL_DUMP);
+    return new PyInt(0);
+}
+
+PyResult LPStore::GetLPExchangeRates(PyCallArgs& call) {
+  /**
+            self.cache.exchangeRates = sm.RemoteSvc('LPSvc').GetLPExchangeRates()
+            */
+  sLog.White( "LPStore::GetLPExchangeRates()", "size=%lu", call.tuple->size());
+
+  call.Dump(SERVICE__CALL_DUMP);
+    PyDict* result = new PyDict();
+    return result;
+}
+
+PyResult LPStore::ExchangeConcordLP(PyCallArgs& call, PyInt* corpID, PyInt* amount) {
+  /**
+            sm.RemoteSvc('LPSvc').ExchangeConcordLP(corpID, amount)
+            */
+  sLog.White( "LPStore::ExchangeConcordLP()", "size=%lu", call.tuple->size());
+
+  call.Dump(SERVICE__CALL_DUMP);
+    return new PyNone;
+}
+
+PyResult LPStore::TakeOffer(PyCallArgs& call, PyInt* corpID, PyInt* offerID, PyInt* quantity) {
+  /**
+            ret = sm.RemoteSvc('LPSvc').TakeOffer(self.cache.corpID, data.offerID, numberOfOffers)
+            */
+  sLog.White( "LPStore::TakeOffer()", "size=%lu", call.tuple->size());
+
+  call.Dump(SERVICE__CALL_DUMP);
+    return new PyBool(true);
 }
 

--- a/src/eve-server/corporation/LPStore.h
+++ b/src/eve-server/corporation/LPStore.h
@@ -37,6 +37,11 @@ class LPStore : public Service<LPStore>
   protected:
       PyResult AcceptOffer(PyCallArgs& call, PyInt* offerID, PyInt* quantity);
       PyResult GetAvailableOffers(PyCallArgs& call);
+      PyResult GetAvailableOffersFromCorp(PyCallArgs& call, PyInt* corpID);
+      PyResult GetLPForCharacterCorp(PyCallArgs& call, PyInt* corpID);
+      PyResult GetLPExchangeRates(PyCallArgs& call);
+      PyResult ExchangeConcordLP(PyCallArgs& call, PyInt* corpID, PyInt* amount);
+      PyResult TakeOffer(PyCallArgs& call, PyInt* corpID, PyInt* offerID, PyInt* quantity);
 };
 
 #endif /* !__LP_STORE_H_INCL__ */

--- a/src/eve-server/crimewatch/CrimeWatchService.cpp
+++ b/src/eve-server/crimewatch/CrimeWatchService.cpp
@@ -1,0 +1,134 @@
+/*
+    ------------------------------------------------------------------------------------
+    LICENSE:
+    ------------------------------------------------------------------------------------
+    This file is part of EVEmu: EVE Online Server Emulator
+    Copyright 2006 - 2021 The EVEmu Team
+    For the latest information visit https://evemu.dev
+    ------------------------------------------------------------------------------------
+    This program is free software; you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License as published by the Free Software
+    Foundation; either version 2 of the License, or (at your option) any later
+    version.
+    This program is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+    FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+    You should have received a copy of the GNU Lesser General Public License along with
+    this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+    Place - Suite 330, Boston, MA 02111-1307, USA, or go to
+    http://www.gnu.org/copyleft/lesser.txt.
+    ------------------------------------------------------------------------------------
+    Author: Zhur
+*/
+
+#include "eve-server.h"
+
+#include "crimewatch/CrimewatchService.h"
+
+CrimewatchService::CrimewatchService(EVEServiceManager& mgr) :
+    BindableService("crimewatch", mgr)
+{
+}
+
+CrimewatchBound::CrimewatchBound(EVEServiceManager& mgr, CrimewatchService& parent, uint32 locationID, uint32 groupID) :
+    EVEBoundObject(mgr, parent),
+    m_locationID(locationID),
+    m_groupID(groupID)
+{
+    this->Add("GetClientStates", &CrimewatchBound::GetClientStates);
+    this->Add("SetSafetyLevel", &CrimewatchBound::SetSafetyLevel);
+    this->Add("GetMySecurityStatus", &CrimewatchBound::GetMySecurityStatus);
+    this->Add("GetCharacterSecurityStatus", &CrimewatchBound::GetCharacterSecurityStatus);
+    this->Add("StartDuelChallenge", &CrimewatchBound::StartDuelChallenge);
+    this->Add("RespondToDuelChallenge", &CrimewatchBound::RespondToDuelChallenge);
+    this->Add("GetMyEngagements", &CrimewatchBound::GetMyEngagements);
+}
+
+BoundDispatcher* CrimewatchService::BindObject(Client* client, PyRep* bindParameters)
+{
+    Crimewatch_BindArgs args;
+    PyRep* tmp(bindParameters->Clone());
+    if (!args.Decode(&tmp)) {
+        codelog(SERVICE__ERROR, "%s: Failed to decode bind args.", this->GetName().c_str());
+        return nullptr;
+    }
+
+    return new CrimewatchBound(this->GetServiceManager(), *this, args.locationID, args.groupID);
+}
+
+void CrimewatchService::BoundReleased(CrimewatchBound* bound)
+{
+}
+
+PyResult CrimewatchBound::GetClientStates(PyCallArgs& call)
+{
+    PyDict* result = new PyDict();
+    
+    PyDict* combatTimers = new PyDict();
+    combatTimers->SetItemString("combatTimers", new PyList());
+    combatTimers->SetItemString("duelTimers", new PyList());
+    combatTimers->SetItemString("weaponTimers", new PyList());
+    combatTimers->SetItemString("otherTimers", new PyList());
+    result->SetItemString("combatTimers", combatTimers);
+    
+    PyDict* engagementsDict = new PyDict();
+    result->SetItemString("engagements", engagementsDict);
+    
+    PyDict* flaggedChars = new PyDict();
+    flaggedChars->SetItemString("chars", new PyList());
+    flaggedChars->SetItemString("ships", new PyList());
+    result->SetItemString("flaggedCharacters", flaggedChars);
+    
+    result->SetItemString("safetyLevel", new PyInt(3));
+    
+    return result;
+}
+
+PyResult CrimewatchBound::SetSafetyLevel(PyCallArgs& call, PyInt* safetyLevel)
+{
+    return PyStatic.NewTrue();
+}
+
+PyResult CrimewatchBound::GetMySecurityStatus(PyCallArgs& call)
+{
+    return new PyFloat(0.0f);
+}
+
+PyResult CrimewatchBound::GetCharacterSecurityStatus(PyCallArgs& call, PyInt* charID)
+{
+    return new PyFloat(0.0f);
+}
+
+PyResult CrimewatchBound::StartDuelChallenge(PyCallArgs& call, PyInt* charID)
+{
+    return PyStatic.NewTrue();
+}
+
+PyResult CrimewatchBound::RespondToDuelChallenge(PyCallArgs& call, PyInt* fromCharID, PyInt* expiryTime, PyBool* accept)
+{
+    return PyStatic.NewTrue();
+}
+
+PyResult CrimewatchBound::GetMyEngagements(PyCallArgs& call)
+{
+    PyDict* engagements = new PyDict();
+    
+    PyDict* engagement = new PyDict();
+    engagement->SetItemString("engagementID", new PyInt(1));
+    engagement->SetItemString("issuerID", new PyInt(1));
+    engagement->SetItemString("charID", new PyInt(90000006));
+    engagement->SetItemString("duration", new PyInt(300));
+    engagement->SetItemString("expiredTime", new PyInt(0));
+    engagement->SetItemString("status", new PyInt(1));
+    engagement->SetItemString("typeID", new PyInt(1));
+    engagement->SetItemString("level", new PyInt(1));
+    engagement->SetItemString("factionID", new PyInt(0));
+    engagement->SetItemString("weaponModifier", new PyInt(0));
+    engagement->SetItemString("shieldModifier", new PyInt(0));
+    engagement->SetItemString("armorModifier", new PyInt(0));
+    engagement->SetItemString("hpModifier", new PyInt(0));
+    
+    engagements->SetItemString("1", engagement);
+    
+    return engagements;
+}

--- a/src/eve-server/crimewatch/CrimeWatchService.cpp
+++ b/src/eve-server/crimewatch/CrimeWatchService.cpp
@@ -62,25 +62,37 @@ void CrimewatchService::BoundReleased(CrimewatchBound* bound)
 
 PyResult CrimewatchBound::GetClientStates(PyCallArgs& call)
 {
-    PyDict* result = new PyDict();
-    
-    PyDict* combatTimers = new PyDict();
-    combatTimers->SetItemString("combatTimers", new PyList());
-    combatTimers->SetItemString("duelTimers", new PyList());
-    combatTimers->SetItemString("weaponTimers", new PyList());
-    combatTimers->SetItemString("otherTimers", new PyList());
-    result->SetItemString("combatTimers", combatTimers);
-    
+    PyTuple* result = new PyTuple(4);
+
+    PyTuple* myCombatTimers = new PyTuple(4);
+    PyTuple* weaponTimer = new PyTuple(2);
+    weaponTimer->SetItem(0, new PyInt(0));
+    weaponTimer->SetItem(1, PyStatic.NewNone());
+    PyTuple* pvpTimer = new PyTuple(2);
+    pvpTimer->SetItem(0, new PyInt(0));
+    pvpTimer->SetItem(1, PyStatic.NewNone());
+    PyTuple* npcTimer = new PyTuple(2);
+    npcTimer->SetItem(0, new PyInt(0));
+    npcTimer->SetItem(1, PyStatic.NewNone());
+    PyTuple* criminalTimer = new PyTuple(2);
+    criminalTimer->SetItem(0, new PyInt(0));
+    criminalTimer->SetItem(1, PyStatic.NewNone());
+    myCombatTimers->SetItem(0, weaponTimer);
+    myCombatTimers->SetItem(1, pvpTimer);
+    myCombatTimers->SetItem(2, npcTimer);
+    myCombatTimers->SetItem(3, criminalTimer);
+    result->SetItem(0, myCombatTimers);
+
     PyDict* engagementsDict = new PyDict();
-    result->SetItemString("engagements", engagementsDict);
-    
-    PyDict* flaggedChars = new PyDict();
-    flaggedChars->SetItemString("chars", new PyList());
-    flaggedChars->SetItemString("ships", new PyList());
-    result->SetItemString("flaggedCharacters", flaggedChars);
-    
-    result->SetItemString("safetyLevel", new PyInt(3));
-    
+    result->SetItem(1, engagementsDict);
+
+    PyTuple* flaggedCharacters = new PyTuple(2);
+    flaggedCharacters->SetItem(0, new PyList());
+    flaggedCharacters->SetItem(1, new PyList());
+    result->SetItem(2, flaggedCharacters);
+
+    result->SetItem(3, new PyInt(3));
+
     return result;
 }
 

--- a/src/eve-server/crimewatch/CrimeWatchService.h
+++ b/src/eve-server/crimewatch/CrimeWatchService.h
@@ -1,0 +1,65 @@
+/*
+    ------------------------------------------------------------------------------------
+    LICENSE:
+    ------------------------------------------------------------------------------------
+    This file is part of EVEmu: EVE Online Server Emulator
+    Copyright 2006 - 2021 The EVEmu Team
+    For the latest information visit https://evemu.dev
+    ------------------------------------------------------------------------------------
+    This program is free software; you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License as published by the Free Software
+    Foundation; either version 2 of the License, or (at your option) any later
+    version.
+    This program is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+    FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+    You should have received a copy of the GNU Lesser General Public License along with
+    this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+    Place - Suite 330, Boston, MA 02111-1307, USA, or go to
+    http://www.gnu.org/copyleft/lesser.txt.
+    ------------------------------------------------------------------------------------
+    Author: Zhur
+*/
+
+#ifndef __CRIMEWATCH_SERVICE_H_INCL__
+#define __CRIMEWATCH_SERVICE_H_INCL__
+
+#include "services/BoundService.h"
+#include "services/ServiceManager.h"
+#include "packets/Crimewatch.h"
+
+class CrimewatchBound;
+
+class CrimewatchService : public BindableService<CrimewatchService, CrimewatchBound>
+{
+public:
+    CrimewatchService(EVEServiceManager& mgr);
+
+    void BoundReleased(CrimewatchBound* bound) override;
+
+protected:
+    BoundDispatcher* BindObject(Client* client, PyRep* bindParameters);
+
+private:
+    friend class CrimewatchBound;
+};
+
+class CrimewatchBound : public EVEBoundObject<CrimewatchBound>
+{
+public:
+    CrimewatchBound(EVEServiceManager& mgr, CrimewatchService& parent, uint32 locationID, uint32 groupID);
+    
+    PyResult GetClientStates(PyCallArgs& call);
+    PyResult SetSafetyLevel(PyCallArgs& call, PyInt* safetyLevel);
+    PyResult GetMySecurityStatus(PyCallArgs& call);
+    PyResult GetCharacterSecurityStatus(PyCallArgs& call, PyInt* charID);
+    PyResult StartDuelChallenge(PyCallArgs& call, PyInt* charID);
+    PyResult RespondToDuelChallenge(PyCallArgs& call, PyInt* fromCharID, PyInt* expiryTime, PyBool* accept);
+    PyResult GetMyEngagements(PyCallArgs& call);
+    
+private:
+    uint32 m_locationID;
+    uint32 m_groupID;
+};
+
+#endif

--- a/src/eve-server/dogmaim/DogmaIMService.cpp
+++ b/src/eve-server/dogmaim/DogmaIMService.cpp
@@ -558,7 +558,19 @@ PyResult DogmaIMBound::GetAllInfo(PyCallArgs& call, PyRep* getCharInfo, PyRep* g
             _log(SERVICE__MESSAGE, "dogmaIM::GetAllInfo returning None (char info failed)");
             return PyStatic.NewNone();
         }
-        rsp->SetItemString("charInfo", charResult);
+        
+        // Create charBrain tuple: (brainID, charEffects, shipEffects, structureEffects)
+        PyTuple* charBrain = new PyTuple(4);
+        charBrain->SetItem(0, new PyInt(pClient->GetCharacterID())); // brainID
+        charBrain->SetItem(1, new PyList()); // charEffects (empty list)
+        charBrain->SetItem(2, new PyList()); // shipEffects (empty list)
+        charBrain->SetItem(3, new PyList()); // structureEffects (empty list)
+        
+        // Create charInfo tuple: (charInfoDict, charBrain)
+        PyTuple* charInfoTuple = new PyTuple(2);
+        charInfoTuple->SetItem(0, charResult);
+        charInfoTuple->SetItem(1, charBrain);
+        rsp->SetItemString("charInfo", charInfoTuple);
     } else {
         rsp->SetItemString("charInfo", new PyDict());
     }

--- a/src/eve-server/dogmaim/DogmaIMService.cpp
+++ b/src/eve-server/dogmaim/DogmaIMService.cpp
@@ -472,7 +472,7 @@ PyResult DogmaIMBound::RemoveTarget(PyCallArgs& call, PyInt* targetID) {
 }
 
 
-PyResult DogmaIMBound::GetAllInfo(PyCallArgs& call, PyBool* getCharInfo, PyBool* getShipInfo)
+PyResult DogmaIMBound::GetAllInfo(PyCallArgs& call, PyObject* getCharInfo, PyObject* getShipInfo)
 {
     // added more return data and updated logic (almost complete and mostly accurate) -allan 26Mar16
     // completed.  -allan 7Jan19
@@ -490,7 +490,15 @@ PyResult DogmaIMBound::GetAllInfo(PyCallArgs& call, PyBool* getCharInfo, PyBool*
         --still dont know what 'datas' are
         ** this has *something* to do with POS
         */
-    if (getShipInfo->value()) {
+    bool getShipInfoValue = false;
+    if (getShipInfo != nullptr && !getShipInfo->IsNone()) {
+        if (getShipInfo->IsBool()) {
+            getShipInfoValue = getShipInfo->AsBool()->value();
+        } else if (getShipInfo->IsInt()) {
+            getShipInfoValue = getShipInfo->AsInt()->value() != 0;
+        }
+    }
+    if (getShipInfoValue) {
         rsp->SetItemString("locationInfo", new PyDict());
     } else {
         rsp->SetItemString("locationInfo", PyStatic.NewNone());
@@ -502,7 +510,15 @@ PyResult DogmaIMBound::GetAllInfo(PyCallArgs& call, PyBool* getCharInfo, PyBool*
 
     // Set "charInfo" in the Dictionary  -fixed 24Mar16
     sItemFactory.SetUsingClient(pClient);
-    if (getCharInfo->value()) {
+    bool getCharInfoValue = false;
+    if (getCharInfo != nullptr && !getCharInfo->IsNone()) {
+        if (getCharInfo->IsBool()) {
+            getCharInfoValue = getCharInfo->AsBool()->value();
+        } else if (getCharInfo->IsInt()) {
+            getCharInfoValue = getCharInfo->AsInt()->value() != 0;
+        }
+    }
+    if (getCharInfoValue) {
         PyDict* charResult = pClient->GetChar()->GetCharInfo();
         if (charResult == nullptr) {
             _log(SERVICE__ERROR, "Unable to build char info for char %u", pClient->GetCharacterID());
@@ -516,7 +532,7 @@ PyResult DogmaIMBound::GetAllInfo(PyCallArgs& call, PyBool* getCharInfo, PyBool*
     }
 
     // Set "shipInfo" in the Dictionary  -fixed 26Mar16
-    if (getShipInfo->value()) {
+    if (getShipInfoValue) {
         PyDict* shipResult = pClient->GetShip()->GetShipInfo();
         if (shipResult == nullptr) {
             _log(SERVICE__ERROR, "Unable to build ship info for ship %u", pClient->GetShipID());

--- a/src/eve-server/dogmaim/DogmaIMService.cpp
+++ b/src/eve-server/dogmaim/DogmaIMService.cpp
@@ -55,9 +55,11 @@ BoundDispatcher* DogmaIMService::BindObject(Client* client, PyRep* bindParameter
     //crap
     PyRep* tmp(bindParameters->Clone());
     if (!args.Decode(&tmp)) {
-        codelog(SERVICE__ERROR, "%s: Failed to decode bind args.", GetName().c_str());
+        codelog(SERVICE__ERROR, "%s: Failed to decode bind args.", this->GetName().c_str());
+        bindParameters->Dump(SERVICE__ERROR, "BindParameters: ");
         return nullptr;
     }
+    codelog(SERVICE__MESSAGE, "%s: Bind args decoded: locationID=%u, groupID=%u", this->GetName().c_str(), args.locationID, args.groupID);
 
     return new DogmaIMBound(this->GetServiceManager(), *this, args.locationID, args.groupID);
 }
@@ -472,16 +474,45 @@ PyResult DogmaIMBound::RemoveTarget(PyCallArgs& call, PyInt* targetID) {
 }
 
 
-PyResult DogmaIMBound::GetAllInfo(PyCallArgs& call, PyObject* getCharInfo, PyObject* getShipInfo)
+PyResult DogmaIMBound::GetAllInfo(PyCallArgs& call, PyRep* getCharInfo, PyRep* getShipInfo, PyRep* getStationInfo)
 {
-    // added more return data and updated logic (almost complete and mostly accurate) -allan 26Mar16
+    _log(SERVICE__MESSAGE, "dogmaIM::GetAllInfo called for client %u", call.client->GetCharacterID());
+
+    // added more more return data and updated logic (almost complete and mostly accurate) -allan 26Mar16
     // completed.  -allan 7Jan19
     // Start the Code
     Client* pClient(call.client);
 
+    _log(SERVICE__MESSAGE, "dogmaIM::GetAllInfo: client=%u, stationID=%d, getCharInfo=%p, getShipInfo=%p, getStationInfo=%p", 
+         pClient->GetCharacterID(), 
+         pClient->GetStationID(),
+         getCharInfo, 
+         getShipInfo, 
+         getStationInfo);
+
     // Create the response dictionary
     PyDict* rsp = new PyDict();
     rsp->SetItemString("activeShipID", new PyInt(pClient->GetShipID()));
+    
+    // Set "structureInfo" in the Dictionary - for station entry
+    if (pClient->GetStationID() != 0) {
+        StationItemRef station = StationItem::Load(pClient->GetStationID());
+        if (station.get() != nullptr) {
+            Rsp_CommonGetInfo_Entry entry;
+            if (station->Populate(entry)) {
+                PyDict* structureInfo = new PyDict();
+                structureInfo->SetItem(new PyInt(pClient->GetStationID()), new PyObject("util.KeyVal", entry.Encode()));
+                rsp->SetItemString("structureInfo", structureInfo);
+            } else {
+                rsp->SetItemString("structureInfo", PyStatic.NewNone());
+            }
+        } else {
+            rsp->SetItemString("structureInfo", PyStatic.NewNone());
+        }
+    } else {
+        rsp->SetItemString("structureInfo", PyStatic.NewNone());
+    }
+    
     // Set "locationInfo" in the Dictionary
     /** @todo  havent found a populated item in packet logs
      *
@@ -524,6 +555,7 @@ PyResult DogmaIMBound::GetAllInfo(PyCallArgs& call, PyObject* getCharInfo, PyObj
             _log(SERVICE__ERROR, "Unable to build char info for char %u", pClient->GetCharacterID());
             sItemFactory.UnsetUsingClient();
             PySafeDecRef(rsp);
+            _log(SERVICE__MESSAGE, "dogmaIM::GetAllInfo returning None (char info failed)");
             return PyStatic.NewNone();
         }
         rsp->SetItemString("charInfo", charResult);
@@ -538,6 +570,7 @@ PyResult DogmaIMBound::GetAllInfo(PyCallArgs& call, PyObject* getCharInfo, PyObj
             _log(SERVICE__ERROR, "Unable to build ship info for ship %u", pClient->GetShipID());
             sItemFactory.UnsetUsingClient();
             PySafeDecRef(rsp);
+            _log(SERVICE__MESSAGE, "dogmaIM::GetAllInfo returning None (ship info failed)");
             return PyStatic.NewNone();
         }
         rsp->SetItemString("shipInfo", shipResult);
@@ -546,22 +579,29 @@ PyResult DogmaIMBound::GetAllInfo(PyCallArgs& call, PyObject* getCharInfo, PyObj
     }
 
     // Set "shipState" in the Dictionary  -fixed 26Mar16  -UD to add linked weapons 7Jan19
+    PyTuple* rspShipState;
     if (pClient->GetShip().get() == nullptr) {
-        _log(SERVICE__ERROR, "Unable to build shipState for %u", pClient->GetShipID());
-        PySafeDecRef(rsp);
-        return PyStatic.NewNone();
-    }
-    PyTuple* rspShipState = new PyTuple(3);
+        _log(SERVICE__WARNING, "Client %u has no ship, returning empty shipState", pClient->GetCharacterID());
+        rspShipState = new PyTuple(3);
+        rspShipState->items[0] = new PyList();        // empty fitted module list
+        rspShipState->items[1] = new PyList();        // empty loaded charges
+        rspShipState->items[2] = new PyList();        // empty linked weapons
+    } else {
+        rspShipState = new PyTuple(3);
         rspShipState->items[0] = pClient->GetShip()->GetShipState();        // fitted module list
         rspShipState->items[1] = pClient->GetShip()->GetChargeState();      // loaded charges (subLocation)
         rspShipState->items[2] = pClient->GetShip()->GetLinkedWeapons();    // linked weapons
+    }
     rsp->SetItemString("shipState", rspShipState);
 
     if (is_log_enabled(SHIP__STATE))
         rsp->Dump(SHIP__STATE, "     ");
 
     sItemFactory.UnsetUsingClient();
-    return new PyObject("util.KeyVal", rsp );
+    _log(SERVICE__MESSAGE, "dogmaIM::GetAllInfo returning valid KeyVal result");
+    PyResult finalResult = new PyObject("util.KeyVal", rsp);
+    _log(SERVICE__MESSAGE, "dogmaIM::GetAllInfo finalResult.ssResult=%p", finalResult.ssResult);
+    return finalResult;
 }
 
 PyResult DogmaIMBound::LinkWeapons(PyCallArgs& call, PyInt* shipID, PyInt* masterID, PyInt* fromID) {

--- a/src/eve-server/dogmaim/DogmaIMService.cpp
+++ b/src/eve-server/dogmaim/DogmaIMService.cpp
@@ -504,13 +504,15 @@ PyResult DogmaIMBound::GetAllInfo(PyCallArgs& call, PyRep* getCharInfo, PyRep* g
                 structureInfo->SetItem(new PyInt(pClient->GetStationID()), new PyObject("util.KeyVal", entry.Encode()));
                 rsp->SetItemString("structureInfo", structureInfo);
             } else {
-                rsp->SetItemString("structureInfo", PyStatic.NewNone());
+                _log(SERVICE__WARNING, "Station::Populate failed for station %u", pClient->GetStationID());
+                rsp->SetItemString("structureInfo", new PyDict());
             }
         } else {
-            rsp->SetItemString("structureInfo", PyStatic.NewNone());
+            _log(SERVICE__WARNING, "Failed to load station %u", pClient->GetStationID());
+            rsp->SetItemString("structureInfo", new PyDict());
         }
     } else {
-        rsp->SetItemString("structureInfo", PyStatic.NewNone());
+        rsp->SetItemString("structureInfo", new PyDict());
     }
     
     // Set "locationInfo" in the Dictionary
@@ -572,7 +574,17 @@ PyResult DogmaIMBound::GetAllInfo(PyCallArgs& call, PyRep* getCharInfo, PyRep* g
         charInfoTuple->SetItem(1, charBrain);
         rsp->SetItemString("charInfo", charInfoTuple);
     } else {
-        rsp->SetItemString("charInfo", new PyDict());
+        // Return empty char info tuple to prevent client errors
+        PyDict* emptyCharInfo = new PyDict();
+        PyTuple* emptyCharBrain = new PyTuple(4);
+        emptyCharBrain->SetItem(0, new PyInt(pClient->GetCharacterID()));
+        emptyCharBrain->SetItem(1, new PyList());
+        emptyCharBrain->SetItem(2, new PyList());
+        emptyCharBrain->SetItem(3, new PyList());
+        PyTuple* charInfoTuple = new PyTuple(2);
+        charInfoTuple->SetItem(0, emptyCharInfo);
+        charInfoTuple->SetItem(1, emptyCharBrain);
+        rsp->SetItemString("charInfo", charInfoTuple);
     }
 
     // Set "shipInfo" in the Dictionary  -fixed 26Mar16
@@ -590,19 +602,109 @@ PyResult DogmaIMBound::GetAllInfo(PyCallArgs& call, PyRep* getCharInfo, PyRep* g
         rsp->SetItemString("shipInfo", new PyDict());
     }
 
-    // Set "shipState" in the Dictionary  -fixed 26Mar16  -UD to add linked weapons 7Jan19
-    PyTuple* rspShipState;
+    // Set "shipState" in the Dictionary
+    // Client expects: (instanceCache, instanceFlagQuantityCache, wbData, heatStates)
+    // instanceCache: dict of itemID -> instance row
+    // instanceFlagQuantityCache: dict of itemID -> dict of flagID -> sublocation data
+    // wbData: dict of masterID -> list of slaveIDs (linked weapons)
+    // heatStates: list of heat states
+    
+    PyTuple* rspShipState = new PyTuple(4);
+    
+    // instanceCache: dict of itemID -> instance row
+    PyDict* instanceCache = new PyDict();
+    // instanceFlagQuantityCache: dict of itemID -> dict of flagID -> sublocation data
+    PyDict* instanceFlagQuantityCache = new PyDict();
+    
     if (pClient->GetShip().get() == nullptr) {
         _log(SERVICE__WARNING, "Client %u has no ship, returning empty shipState", pClient->GetCharacterID());
-        rspShipState = new PyTuple(3);
-        rspShipState->items[0] = new PyList();        // empty fitted module list
-        rspShipState->items[1] = new PyList();        // empty loaded charges
-        rspShipState->items[2] = new PyList();        // empty linked weapons
+        rspShipState->SetItem(0, instanceCache);
+        rspShipState->SetItem(1, instanceFlagQuantityCache);
+        rspShipState->SetItem(2, new PyDict());  // empty wbData
+        rspShipState->SetItem(3, new PyList());  // empty heat states
     } else {
-        rspShipState = new PyTuple(3);
-        rspShipState->items[0] = pClient->GetShip()->GetShipState();        // fitted module list
-        rspShipState->items[1] = pClient->GetShip()->GetChargeState();      // loaded charges (subLocation)
-        rspShipState->items[2] = pClient->GetShip()->GetLinkedWeapons();    // linked weapons
+        // Get ship state data
+        PyDict* shipState = pClient->GetShip()->GetShipState();
+        if (shipState != nullptr) {
+            // Convert shipState to instanceCache format
+            for (PyDict::const_iterator itr = shipState->begin(); itr != shipState->end(); ++itr) {
+                PyInt* itemID = itr->first->AsInt();
+                PyPackedRow* statusRow = itr->second->AsPackedRow();
+                if (itemID != nullptr && statusRow != nullptr) {
+                    // Create instance row: [itemID, attribute1, attribute2, ...]
+                    PyList* instanceRow = new PyList();
+                    instanceRow->AddItem(itemID->Clone());
+                    // Add attributes from status row
+                    uint32 instanceIDIndex = statusRow->header()->FindColumn("instanceID");
+                    uint32 onlineIndex = statusRow->header()->FindColumn("online");
+                    uint32 damageIndex = statusRow->header()->FindColumn("damage");
+                    uint32 chargeIndex = statusRow->header()->FindColumn("charge");
+                    uint32 skillPointsIndex = statusRow->header()->FindColumn("skillPoints");
+                    uint32 armorDamageIndex = statusRow->header()->FindColumn("armorDamage");
+                    uint32 shieldChargeIndex = statusRow->header()->FindColumn("shieldCharge");
+                    uint32 incapacitatedIndex = statusRow->header()->FindColumn("incapacitated");
+                    
+                    instanceRow->AddItem(statusRow->GetField(instanceIDIndex)->Clone());
+                    instanceRow->AddItem(statusRow->GetField(onlineIndex)->Clone());
+                    instanceRow->AddItem(statusRow->GetField(damageIndex)->Clone());
+                    instanceRow->AddItem(statusRow->GetField(chargeIndex)->Clone());
+                    instanceRow->AddItem(statusRow->GetField(skillPointsIndex)->Clone());
+                    instanceRow->AddItem(statusRow->GetField(armorDamageIndex)->Clone());
+                    instanceRow->AddItem(statusRow->GetField(shieldChargeIndex)->Clone());
+                    instanceRow->AddItem(statusRow->GetField(incapacitatedIndex)->Clone());
+                    
+                    instanceCache->SetItem(itemID->Clone(), instanceRow);
+                }
+            }
+            PyDecRef(shipState);
+        }
+        
+        // Get charge state data
+        PyDict* chargeState = pClient->GetShip()->GetChargeState();
+        if (chargeState != nullptr) {
+            // Convert chargeState to instanceFlagQuantityCache format
+            for (PyDict::const_iterator itr = chargeState->begin(); itr != chargeState->end(); ++itr) {
+                PyInt* flagID = itr->first->AsInt();
+                PyPackedRow* chargeRow = itr->second->AsPackedRow();
+                if (flagID != nullptr && chargeRow != nullptr) {
+                    // Get shipID from charge row
+                    uint32 instanceIDIndex = chargeRow->header()->FindColumn("instanceID");
+                    uint32 typeIDIndex = chargeRow->header()->FindColumn("typeID");
+                    PyInt* shipID = chargeRow->GetField(instanceIDIndex)->AsInt();
+                    if (shipID != nullptr) {
+                        // Get or create flag dict for this ship
+                        PyDict* flagDict = nullptr;
+                        PyRep* existingFlagDict = instanceFlagQuantityCache->GetItem(shipID);
+                        if (existingFlagDict != nullptr) {
+                            flagDict = existingFlagDict->AsDict();
+                        } else {
+                            flagDict = new PyDict();
+                            instanceFlagQuantityCache->SetItem(shipID->Clone(), flagDict);
+                        }
+                        
+                        // Create sublocation data: [flagID, typeID]
+                        PyList* sublocation = new PyList();
+                        sublocation->AddItem(flagID->Clone());
+                        sublocation->AddItem(chargeRow->GetField(typeIDIndex)->Clone());
+                        
+                        flagDict->SetItem(flagID->Clone(), sublocation);
+                    }
+                }
+            }
+            PyDecRef(chargeState);
+        }
+        
+        // Get linked weapons data (wbData)
+        PyRep* linkedWeapons = pClient->GetShip()->GetLinkedWeapons();
+        if (linkedWeapons == nullptr || linkedWeapons->IsNone()) {
+            rspShipState->SetItem(2, new PyDict());  // empty wbData
+        } else {
+            rspShipState->SetItem(2, linkedWeapons);
+        }
+        
+        rspShipState->SetItem(0, instanceCache);
+        rspShipState->SetItem(1, instanceFlagQuantityCache);
+        rspShipState->SetItem(3, new PyList());  // empty heat states
     }
     rsp->SetItemString("shipState", rspShipState);
 

--- a/src/eve-server/dogmaim/DogmaIMService.h
+++ b/src/eve-server/dogmaim/DogmaIMService.h
@@ -70,7 +70,7 @@ protected:
     PyResult StopOverloadRack(PyCallArgs& call, PyInt* itemID);
     PyResult CharGetInfo(PyCallArgs& call);
     PyResult ItemGetInfo(PyCallArgs& call, PyInt* itemID);
-    PyResult GetAllInfo(PyCallArgs& call, PyObject* getCharInfo, PyObject* getShipInfo);
+    PyResult GetAllInfo(PyCallArgs& call, PyRep* getCharInfo, PyRep* getShipInfo, PyRep* getStationInfo = nullptr);
     PyResult DestroyWeaponBank(PyCallArgs& call, PyInt* shipID, PyInt* itemID);
     PyResult GetCharacterBaseAttributes(PyCallArgs& call);
     PyResult Activate(PyCallArgs& call, PyInt* itemID, PyInt* effectID);

--- a/src/eve-server/dogmaim/DogmaIMService.h
+++ b/src/eve-server/dogmaim/DogmaIMService.h
@@ -70,7 +70,7 @@ protected:
     PyResult StopOverloadRack(PyCallArgs& call, PyInt* itemID);
     PyResult CharGetInfo(PyCallArgs& call);
     PyResult ItemGetInfo(PyCallArgs& call, PyInt* itemID);
-    PyResult GetAllInfo(PyCallArgs& call, PyBool* getCharInfo, PyBool* getShipInfo);
+    PyResult GetAllInfo(PyCallArgs& call, PyObject* getCharInfo, PyObject* getShipInfo);
     PyResult DestroyWeaponBank(PyCallArgs& call, PyInt* shipID, PyInt* itemID);
     PyResult GetCharacterBaseAttributes(PyCallArgs& call);
     PyResult Activate(PyCallArgs& call, PyInt* itemID, PyInt* effectID);

--- a/src/eve-server/dogmaim/GodmaService.cpp
+++ b/src/eve-server/dogmaim/GodmaService.cpp
@@ -1,0 +1,123 @@
+/*
+    ------------------------------------------------------------------------------------
+    LICENSE:
+    ------------------------------------------------------------------------------------
+    This file is part of EVEmu: EVE Online Server Emulator
+    Copyright 2006 - 2021 The EVEmu Team
+    For the latest information visit https://evemu.dev
+    ------------------------------------------------------------------------------------
+    This program is free software; you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License as published by the Free Software
+    Foundation; either version 2 of the License, or (at your option) any later
+    version.
+
+    This program is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+    FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License along with
+    this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+    Place - Suite 330, Boston, MA 02111-1307, USA, or go to
+    http://www.gnu.org/copyleft/lesser.txt.
+    ------------------------------------------------------------------------------------
+    Author:        EVEmu Team
+*/
+
+#include "eve-server.h"
+
+#include "dogmaim/GodmaService.h"
+#include "character/Character.h"
+#include "Client.h"
+
+#include <set>
+
+GodmaService::GodmaService() :
+    Service("godma")
+{
+    this->Add("GetItem", &GodmaService::GetItem);
+    this->Add("GetType", &GodmaService::GetType);
+    this->Add("GetStateManager", &GodmaService::GetStateManager);
+}
+
+PyResult GodmaService::GetItem(PyCallArgs& call, PyInt* itemID)
+{
+    sLog.Debug("GodmaService", "GetItem called for itemID %u", itemID->value());
+    
+    CharacterRef charRef = call.client->GetChar();
+    if (charRef.get() == nullptr) {
+        sLog.Error("GodmaService", "GetItem: Character not found");
+        return PyStatic.NewNone();
+    }
+    
+    if (itemID->value() != charRef->itemID()) {
+        sLog.Error("GodmaService", "GetItem: Requested itemID %u does not match character ID %u", 
+                   itemID->value(), charRef->itemID());
+        return PyStatic.NewNone();
+    }
+    
+    int64 itemTime = GetFileTimeNow();
+    int64 wallclockTime = GetFileTimeNow();
+    
+    PyDict* result = new PyDict();
+    
+    result->SetItemString("itemID", new PyInt(charRef->itemID()));
+    result->SetItemString("time", new PyLong(itemTime));
+    result->SetItemString("wallclockTime", new PyLong(wallclockTime));
+    
+    PyObject* invItem = new PyObject("util.KeyVal", new PyDict());
+    PyDict* invItemDict = invItem->AsDict();
+    invItemDict->SetItemString("itemID", new PyInt(charRef->itemID()));
+    invItemDict->SetItemString("typeID", new PyInt(charRef->typeID()));
+    invItemDict->SetItemString("ownerID", new PyInt(charRef->ownerID()));
+    invItemDict->SetItemString("locationID", new PyInt(charRef->locationID()));
+    invItemDict->SetItemString("flagID", new PyInt(charRef->flag()));
+    invItemDict->SetItemString("quantity", new PyInt(1));
+    invItemDict->SetItemString("singleton", new PyInt(1));
+    result->SetItemString("invItem", invItem);
+    
+    result->SetItemString("description", new PyString(charRef->description().c_str()));
+    
+    PyDict* activeEffects = new PyDict();
+    result->SetItemString("activeEffects", activeEffects);
+    
+    PyDict* attributes = new PyDict();
+    
+    AttributeMap* attrMap = charRef->GetAttributeMap();
+    if (attrMap != nullptr) {
+        DBQueryResult res;
+        if (sDatabase.RunQuery(res, "SELECT attributeID FROM dgmAttributeTypes")) {
+            std::set<uint32> validAttributes;
+            DBResultRow row;
+            while (res.GetRow(row)) {
+                validAttributes.insert(row.GetUInt(0));
+            }
+            
+            for (auto attr = attrMap->begin(); attr != attrMap->end(); ++attr) {
+                uint32 attributeID = attr->first;
+                if (validAttributes.find(attributeID) != validAttributes.end()) {
+                    attributes->SetItem(new PyInt(attributeID), attr->second.GetPyObject());
+                } else {
+                    sLog.Warning("GodmaService", "GetItem: Attribute %u not found in dgmAttributeTypes, skipping", attributeID);
+                }
+            }
+        }
+    }
+    result->SetItemString("attributes", attributes);
+    
+    PyDict* boosters = new PyDict();
+    result->SetItemString("boosters", boosters);
+    
+    return result;
+}
+
+PyResult GodmaService::GetType(PyCallArgs& call, PyInt* typeID)
+{
+    sLog.Debug("GodmaService", "GetType called for typeID %u", typeID->value());
+    return PyStatic.NewNone();
+}
+
+PyResult GodmaService::GetStateManager(PyCallArgs& call)
+{
+    sLog.Debug("GodmaService", "GetStateManager called");
+    return PyStatic.NewNone();
+}

--- a/src/eve-server/dogmaim/GodmaService.h
+++ b/src/eve-server/dogmaim/GodmaService.h
@@ -20,50 +20,23 @@
     Place - Suite 330, Boston, MA 02111-1307, USA, or go to
     http://www.gnu.org/copyleft/lesser.txt.
     ------------------------------------------------------------------------------------
-    Author:        Zhur
+    Author:        EVEmu Team
 */
 
+#ifndef __GODMA_SERVICE_H_INCL__
+#define __GODMA_SERVICE_H_INCL__
 
-#ifndef __INSURANCE_SERVICE_H_INCL__
-#define __INSURANCE_SERVICE_H_INCL__
+#include "services/Service.h"
 
-#include "ship/ShipDB.h"
-#include "services/BoundService.h"
-
-class InsuranceBound;
-
-class InsuranceService : public BindableService <InsuranceService, InsuranceBound> {
-public:
-    InsuranceService(EVEServiceManager& mgr);
-
-    void BoundReleased (InsuranceBound* bound) override;
-
-protected:
-    ShipDB m_db;
-
-    PyResult GetContractForShip(PyCallArgs& call, PyInt* shipID);
-    PyResult GetInsurancePrice(PyCallArgs& call, PyInt* typeID);
-    PyResult GetInsurancePrices(PyCallArgs& call, PyList* typeIDs);
-
-    BoundDispatcher* BindObject(Client *client, PyRep* bindParameters);
-};
-
-class InsuranceBound : public EVEBoundObject <InsuranceBound>
+class GodmaService : public Service<GodmaService>
 {
 public:
-    InsuranceBound(EVEServiceManager& mgr, InsuranceService& parent, ShipDB* db);
+    GodmaService();
 
 protected:
-    PyResult InsureShip(PyCallArgs& call, PyInt* shipID, PyFloat* amount, std::optional<PyInt*> isCorporation);
-    PyResult UnInsureShip(PyCallArgs& call, PyInt* shipID);
-    PyResult GetContracts(PyCallArgs& call, std::optional<PyRep*> isCorporation);
-    PyResult GetInsurancePrice(PyCallArgs& call, PyInt* typeID);
-
-protected:
-    ShipDB* m_db;
-    LSCService* m_lsc;
+    PyResult GetItem(PyCallArgs& call, PyInt* itemID);
+    PyResult GetType(PyCallArgs& call, PyInt* typeID);
+    PyResult GetStateManager(PyCallArgs& call);
 };
 
 #endif
-
-

--- a/src/eve-server/eve-server.cpp
+++ b/src/eve-server/eve-server.cpp
@@ -57,6 +57,8 @@
 #include "agents/AgentMgrService.h"
 // alliance services
 #include "alliance/AllianceRegistry.h"
+// bounty services
+#include "bounty/BountyProxyService.h"
 // calendar services
 #include "system/CalendarMgrService.h"
 #include "system/CalendarProxy.h"
@@ -98,6 +100,7 @@
 // dogmaim services
 #include "dogmaim/DogmaIMService.h"
 #include "dogmaim/DogmaService.h"
+#include "dogmaim/GodmaService.h"
 // crimewatch service
 #include "crimewatch/CrimewatchService.h"
 #include "projectdiscovery/ProjectDiscoveryService.h"
@@ -162,6 +165,9 @@
 // ship services
 #include "ship/BeyonceService.h"
 #include "ship/ShipService.h"
+#include "ship/ShipSkinMgrService.h"
+#include "ship/FighterMgrService.h"
+#include "ship/ShipKillCounterService.h"
 // standing services
 #include "standing/Standing.h"
 #include "standing/StandingMgr.h"
@@ -691,6 +697,7 @@ int main( int argc, char* argv[] )
     newSvcMgr.Register(new EntityService(newSvcMgr));
     newSvcMgr.Register(new FleetProxy());
     newSvcMgr.Register(new DogmaService());
+    newSvcMgr.Register(new GodmaService());
     newSvcMgr.Register(new BeyonceService(newSvcMgr));
     newSvcMgr.Register(new DungeonService());
     newSvcMgr.Register(new LookupService());
@@ -699,6 +706,9 @@ int main( int argc, char* argv[] )
     newSvcMgr.Register(new AgentMgrService(newSvcMgr));
     newSvcMgr.Register(new ScanMgrService(newSvcMgr));
     newSvcMgr.Register(new ShipService(newSvcMgr));
+    newSvcMgr.Register(new ShipSkinMgrService());
+    newSvcMgr.Register(new FighterMgrService());
+    newSvcMgr.Register(new ShipKillCounterService());
     newSvcMgr.Register(new SkillMgrService(newSvcMgr));
     newSvcMgr.Register(new TradeService(newSvcMgr));
     newSvcMgr.Register(new PlanetORB(newSvcMgr));
@@ -764,6 +774,7 @@ int main( int argc, char* argv[] )
     newSvcMgr.Register(new StructureSettingsService());
     newSvcMgr.Register(new StructureDirectoryService());
     newSvcMgr.Register(new SeasonManagerService());
+    newSvcMgr.Register(new BountyProxyService());
 
     // keep a reference to cache in the old manager so it still works
     // TODO: REMOVE ONCE THE CHANGES ARE DONE

--- a/src/eve-server/eve-server.cpp
+++ b/src/eve-server/eve-server.cpp
@@ -73,6 +73,7 @@
 #include "character/PaperDollService.h"
 #include "character/PhotoUploadService.h"
 #include "character/SkillMgrService.h"
+#include "skillmgr2/SkillMgr2Service.h"
 // chat services
 #include "chat/LookupService.h"
 #include "chat/LSCService.h"
@@ -97,6 +98,15 @@
 // dogmaim services
 #include "dogmaim/DogmaIMService.h"
 #include "dogmaim/DogmaService.h"
+// crimewatch service
+#include "crimewatch/CrimewatchService.h"
+#include "projectdiscovery/ProjectDiscoveryService.h"
+#include "eventlog/EventLogService.h"
+#include "lscproxy/LSCProxyService.h"
+#include "achievementtracker/AchievementTrackerMgrService.h"
+#include "structuresettings/StructureSettingsService.h"
+#include "structuredirectory/StructureDirectoryService.h"
+#include "seasonmanager/SeasonManagerService.h"
 #include "effects/EffectsDataMgr.h"
 // dungeon services
 #include "dungeon/DungeonExplorationMgrService.h"
@@ -744,7 +754,16 @@ int main( int argc, char* argv[] )
     newSvcMgr.Register(new InsuranceService(newSvcMgr));
     newSvcMgr.Register(new AllianceRegistry(newSvcMgr));
     newSvcMgr.Register(new DogmaIMService(newSvcMgr));
+    newSvcMgr.Register(new CrimewatchService(newSvcMgr));
     newSvcMgr.Register(new CorpRegistryService(newSvcMgr));
+    newSvcMgr.Register(new SkillMgr2Service(newSvcMgr));
+    newSvcMgr.Register(new ProjectDiscoveryService());
+    newSvcMgr.Register(new EventLogService());
+    newSvcMgr.Register(new LSCProxyService());
+    newSvcMgr.Register(new AchievementTrackerMgrService());
+    newSvcMgr.Register(new StructureSettingsService());
+    newSvcMgr.Register(new StructureDirectoryService());
+    newSvcMgr.Register(new SeasonManagerService());
 
     // keep a reference to cache in the old manager so it still works
     // TODO: REMOVE ONCE THE CHANGES ARE DONE

--- a/src/eve-server/eve-server.h
+++ b/src/eve-server/eve-server.h
@@ -72,6 +72,8 @@
 #include "packets/Character.h"
 #include "packets/Destiny.h"
 #include "packets/DogmaIM.h"
+// crimewatch
+#include "packets/Crimewatch.h"
 //  #include "packets/Fleet.h"
 #include "packets/General.h"
 #include "packets/Inventory.h"

--- a/src/eve-server/eventlog/EventLogService.cpp
+++ b/src/eve-server/eventlog/EventLogService.cpp
@@ -1,0 +1,44 @@
+/*
+    ------------------------------------------------------------------------------------
+    LICENSE:
+    ------------------------------------------------------------------------------------
+    This file is part of EVEmu: EVE Online Server Emulator
+    Copyright 2006 - 2021 The EVEmu Team
+    For the latest information visit https://evemu.dev
+    ------------------------------------------------------------------------------------
+    This program is free software; you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License as published by the Free Software
+    Foundation; either version 2 of the License, or (at your option) any later
+    version.
+    This program is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+    FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+    You should have received a copy of the GNU Lesser General Public License along with
+    this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+    Place - Suite 330, Boston, MA 02111-1307, USA, or go to
+    http://www.gnu.org/copyleft/lesser.txt.
+    ------------------------------------------------------------------------------------
+    Author: Zhur
+*/
+
+#include "eve-server.h"
+
+#include "eventlog/EventLogService.h"
+
+EventLogService::EventLogService() :
+    Service("eventLog")
+{
+    this->Add("LogClientStats", &EventLogService::LogClientStats);
+    this->Add("LogString", &EventLogService::LogString);
+}
+
+PyResult EventLogService::LogClientStats(PyCallArgs& call)
+{
+    sLog.Debug("EventLogService", "LogClientStats called - stub");
+    return PyStatic.NewNone();
+}
+
+PyResult EventLogService::LogString(PyCallArgs &call, PyString* arg) {
+    sLog.Error("LogFromClient", "%s", arg->content ().c_str());
+    return PyStatic.NewNone();
+}

--- a/src/eve-server/eventlog/EventLogService.h
+++ b/src/eve-server/eventlog/EventLogService.h
@@ -1,0 +1,38 @@
+/*
+    ------------------------------------------------------------------------------------
+    LICENSE:
+    ------------------------------------------------------------------------------------
+    This file is part of EVEmu: EVE Online Server Emulator
+    Copyright 2006 - 2021 The EVEmu Team
+    For the latest information visit https://evemu.dev
+    ------------------------------------------------------------------------------------
+    This program is free software; you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License as published by the Free Software
+    Foundation; either version 2 of the License, or (at your option) any later
+    version.
+    This program is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+    FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+    You should have received a copy of the GNU Lesser General Public License along with
+    this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+    Place - Suite 330, Boston, MA 02111-1307, USA, or go to
+    http://www.gnu.org/copyleft/lesser.txt.
+    ------------------------------------------------------------------------------------
+    Author: Zhur
+*/
+
+#ifndef __EVENTLOG_SERVICE_H_INCL__
+#define __EVENTLOG_SERVICE_H_INCL__
+
+#include "services/Service.h"
+
+class EventLogService : public Service <EventLogService> {
+public:
+    EventLogService();
+
+protected:
+    PyResult LogClientStats(PyCallArgs &call);
+    PyResult LogString(PyCallArgs &call, PyString* arg);
+};
+
+#endif

--- a/src/eve-server/faction/FactionWarMgrDB.cpp
+++ b/src/eve-server/faction/FactionWarMgrDB.cpp
@@ -45,7 +45,14 @@ PyRep *FactionWarMgrDB::GetWarFactions() {
         return nullptr;
     }
 
-    return DBResultToIntIntDict(res);
+    _log(DATABASE__RESULTS, "GetWarFactions query returned %lu rows", res.GetRowCount());
+    
+    PyRep* result = DBResultToIntIntDict(res);
+    if (result != nullptr) {
+        _log(DATABASE__INFO, "GetWarFactions returned %d factions", ((PyDict*)result)->size());
+    }
+    
+    return result;
 }
 
 PyRep* FactionWarMgrDB::GetFacWarSystems()
@@ -58,6 +65,8 @@ PyRep* FactionWarMgrDB::GetFacWarSystems()
         return nullptr;
     }
 
+    _log(DATABASE__RESULTS, "GetFacWarSystems query returned %lu rows", res.GetRowCount());
+    
     PyDict* result = new PyDict();
     PyDict* dict;
     DBResultRow row;
@@ -67,6 +76,9 @@ PyRep* FactionWarMgrDB::GetFacWarSystems()
         dict->SetItemString("factionID", new PyInt(row.GetInt(2)));
         result->SetItem(new PyInt(row.GetInt(0)), dict );
     }
+    
+    _log(DATABASE__INFO, "GetFacWarSystems returned %d systems", result->size());
+    
     return result;
 }
 

--- a/src/eve-server/faction/FactionWarMgrService.cpp
+++ b/src/eve-server/faction/FactionWarMgrService.cpp
@@ -47,6 +47,7 @@ FactionWarMgrService::FactionWarMgrService(EVEServiceManager& mgr) :
 {
     this->Add("GetWarFactions", &FactionWarMgrService::GetWarFactions);
     this->Add("GetFWSystems", &FactionWarMgrService::GetFWSystems);
+    this->Add("GetFacWarSystems", &FactionWarMgrService::GetFacWarSystems);
     this->Add("GetMyCharacterRankOverview", &FactionWarMgrService::GetMyCharacterRankOverview);
     this->Add("GetMyCharacterRankInfo", &FactionWarMgrService::GetMyCharacterRankInfo);
     this->Add("GetFactionMilitiaCorporation", &FactionWarMgrService::GetFactionMilitiaCorporation);
@@ -77,16 +78,43 @@ FactionWarMgrService::FactionWarMgrService(EVEServiceManager& mgr) :
     this->Add("RefreshCorps", &FactionWarMgrService::RefreshCorps);
 
     this->m_cache = this->m_manager.Lookup <ObjCacheService>("objectCaching");
+    
+    if (this->m_cache == nullptr)
+    {
+        sLog.Error("FactionWarMgrService", "Failed to lookup objectCaching service");
+    }
+    else
+    {
+        sLog.Debug("FactionWarMgrService", "objectCaching service found");
+    }
 }
 
 PyResult FactionWarMgrService::GetWarFactions(PyCallArgs &call) {
     ObjectCachedMethodID method_id(GetName().c_str(), "GetWarFactions");
 
     if (!this->m_cache->IsCacheLoaded(method_id)) {
+        sLog.Debug("FactionWarMgrService", "GetWarFactions cache not loaded, querying database");
+        
         PyRep *res = m_db.GetWarFactions();
-        if (res == NULL)
+        if (res == NULL) {
+            sLog.Error("FactionWarMgrService", "GetWarFactions returned NULL");
             return nullptr;
+        }
+        
+        sLog.Debug("FactionWarMgrService", "GetWarFactions returned valid result, size=%d", ((PyDict*)res)->size());
         this->m_cache->GiveCache(method_id, &res);
+        
+        if (res != nullptr) {
+            sLog.Error("FactionWarMgrService", "GiveCache did not consume res, memory leak!");
+        }
+        
+        if (!this->m_cache->IsCacheLoaded(method_id)) {
+            sLog.Error("FactionWarMgrService", "GetWarFactions cache failed to load");
+            return nullptr;
+        }
+    }
+    else {
+        sLog.Debug("FactionWarMgrService", "GetWarFactions cache already loaded");
     }
 
     return this->m_cache->MakeObjectCachedMethodCallResult(method_id);
@@ -94,34 +122,58 @@ PyResult FactionWarMgrService::GetWarFactions(PyCallArgs &call) {
 
 PyResult FactionWarMgrService::GetFWSystems(PyCallArgs& call)
 {
-    /*
-      [PySubStream 3625 bytes]
-        [PyDict 171 kvp]
-          [PyInt 30002813]
-          [PyDict 2 kvp]
-            [PyString "occupierID"]
-            [PyInt 500001]
-            [PyString "factionID"]
-            [PyInt 500001]
-          [PyInt 30005295]
-          [PyDict 2 kvp]
-            [PyString "occupierID"]
-            [PyInt 500004]
-            [PyString "factionID"]
-            [PyInt 500004]
-            */
     ObjectCachedMethodID method_id( GetName().c_str(), "GetFacWarSystems" );
 
     if ( !this->m_cache->IsCacheLoaded( method_id ) )
     {
+        sLog.Debug("FactionWarMgrService", "GetFacWarSystems cache not loaded, querying database");
+        
         PyRep* res = m_db.GetFacWarSystems();
         if ( res == NULL )
-            return nullptr;
+        {
+            sLog.Error("FactionWarMgrService", "GetFacWarSystems returned NULL, creating empty dict");
+            res = new PyDict();
+        }
+        else
+        {
+            sLog.Debug("FactionWarMgrService", "GetFacWarSystems returned valid result, size=%d", ((PyDict*)res)->size());
+        }
 
+        sLog.Debug("FactionWarMgrService", "Calling GiveCache for GetFacWarSystems");
         this->m_cache->GiveCache( method_id, &res );
+        
+        if (res != nullptr)
+        {
+            sLog.Error("FactionWarMgrService", "GiveCache did not consume res, memory leak!");
+        }
+        
+        if (this->m_cache->IsCacheLoaded(method_id))
+        {
+            sLog.Debug("FactionWarMgrService", "GetFacWarSystems cache loaded successfully");
+        }
+        else
+        {
+            sLog.Error("FactionWarMgrService", "GetFacWarSystems cache failed to load");
+            return nullptr;
+        }
+    }
+    else
+    {
+        sLog.Debug("FactionWarMgrService", "GetFacWarSystems cache already loaded");
     }
 
-    return this->m_cache->MakeObjectCachedMethodCallResult( method_id );
+    PyObject* result = this->m_cache->MakeObjectCachedMethodCallResult( method_id );
+    if (result == nullptr)
+    {
+        sLog.Error("FactionWarMgrService", "MakeObjectCachedMethodCallResult returned nullptr");
+    }
+    
+    return result;
+}
+
+PyResult FactionWarMgrService::GetFacWarSystems(PyCallArgs& call)
+{
+    return GetFWSystems(call);
 }
 
 /**     ***********************************************************************

--- a/src/eve-server/faction/FactionWarMgrService.h
+++ b/src/eve-server/faction/FactionWarMgrService.h
@@ -38,6 +38,7 @@ public:
 protected:
     PyResult GetWarFactions(PyCallArgs& call);
     PyResult GetFWSystems(PyCallArgs& call); 
+    PyResult GetFacWarSystems(PyCallArgs& call);
     PyResult GetMyCharacterRankOverview(PyCallArgs& call);
     PyResult GetMyCharacterRankInfo(PyCallArgs& call);
     PyResult GetFactionMilitiaCorporation(PyCallArgs& call, PyInt* factionID);

--- a/src/eve-server/inventory/AttributeEnum.h
+++ b/src/eve-server/inventory/AttributeEnum.h
@@ -1704,7 +1704,7 @@ enum EveAttrEnum {
     AttrScanDurationBonus = 1906,  // not used
     AttrScanStrengthBonusModule = 1907,  // not used
     AttrScanWormholeStrength = 1908,  // not used
-    AttrDScanImmune = 1958      // not used, but neat idea
+    AttrDScanImmune = 1958 ,     // not used, but neat idea
     /*
     warfareLinkCPUAdd   1882
     warfareLinkCPUPenalty   1883
@@ -1809,7 +1809,9 @@ enum EveAttrEnum {
     modeSignatureRadiusPostDiv  2001
     modeAgilityPostDiv  2002
     modeVelocityPostDiv     2003
+    
     */
+    AttrFighterCapacity = 2055
 };
 
 #endif // AttributeEnum_h__

--- a/src/eve-server/inventory/InvBrokerService.cpp
+++ b/src/eve-server/inventory/InvBrokerService.cpp
@@ -54,7 +54,7 @@ BoundDispatcher* InvBrokerService::BindObject(Client* client, PyRep* bindParamet
     //crap
     PyRep* tmp(bindParameters->Clone());
     if (!args.Decode(&tmp)) {
-        codelog(SERVICE__ERROR, "%s: Failed to decode bind args.", GetName().c_str());
+        codelog(SERVICE__ERROR, "%s: Failed to decode bind args.", this->GetName().c_str());
         return nullptr;
     }
 

--- a/src/eve-server/inventory/InventoryItem.cpp
+++ b/src/eve-server/inventory/InventoryItem.cpp
@@ -1211,6 +1211,7 @@ bool InventoryItem::Populate(Rsp_CommonGetInfo_Entry& result )
     PySafeDecRef(result.itemID);
     PySafeDecRef(result.invItem);
     result.time = GetFileTimeNow();
+    result.wallclockTime = GetFileTimeNow();
     // this is only to display item name in logs.  client ignores it
     result.description = m_data.name;
 

--- a/src/eve-server/inventory/InventoryItem.cpp
+++ b/src/eve-server/inventory/InventoryItem.cpp
@@ -1272,6 +1272,12 @@ bool InventoryItem::Populate(Rsp_CommonGetInfo_Entry& result )
         }
     }
 
+    if (m_type.categoryID() == EVEDB::invCategories::Ship) {
+        if (result.attributes.find(AttrFighterCapacity) == result.attributes.end()) {
+            result.attributes[AttrFighterCapacity] = new PyInt(0);
+        }
+    }
+
     return true;
 }
 

--- a/src/eve-server/lscproxy/LSCProxyService.cpp
+++ b/src/eve-server/lscproxy/LSCProxyService.cpp
@@ -26,11 +26,12 @@
 #include "lscproxy/LSCProxyService.h"
 
 LSCProxyService::LSCProxyService() :
-    Service("lscProxy")
+    Service<LSCProxyService>("lscProxy")
 {
     this->Add("GetChannels", &LSCProxyService::GetChannels);
     this->Add("JoinChannels", &LSCProxyService::JoinChannels);
     this->Add("LeaveChannels", &LSCProxyService::LeaveChannels);
+    this->Add("LeaveChannel", &LSCProxyService::LeaveChannel);
     this->Add("CreateChannel", &LSCProxyService::CreateChannel);
     this->Add("Configure", &LSCProxyService::Configure);
     this->Add("DestroyChannel", &LSCProxyService::DestroyChannel);
@@ -53,13 +54,51 @@ PyResult LSCProxyService::GetChannels(PyCallArgs& call)
 
 PyResult LSCProxyService::JoinChannels(PyCallArgs& call)
 {
-    sLog.Debug("LSCProxyService", "JoinChannels called - returning empty list");
-    return new PyList();
+    sLog.Debug("LSCProxyService", "JoinChannels called");
+    
+    PyList* result = new PyList();
+    
+    // Get the list of channel IDs from the call arguments
+    // The call arguments are: (channelIDs, role)
+    // where channelIDs is a list of channel IDs or tuples
+    if (call.tuple && call.tuple->size() > 0) {
+        PyList* channelIDs = call.tuple->GetItem(0)->AsList();
+        if (channelIDs != nullptr) {
+            sLog.Debug("LSCProxyService", "JoinChannels: Processing %zu channel IDs", channelIDs->size());
+            for (size_t i = 0; i < channelIDs->size(); ++i) {
+                PyInt* channelID = channelIDs->GetItem(i)->AsInt();
+                if (channelID != nullptr) {
+                    // Create a tuple for each channel: (channelID, ok, tmp)
+                    PyTuple* channelTuple = new PyTuple(3);
+                    channelTuple->SetItem(0, channelID->Clone()); // channelID
+                    channelTuple->SetItem(1, new PyInt(0)); // ok = 0 (failed)
+                    channelTuple->SetItem(2, PyStatic.NewNone()); // tmp = None
+                    result->AddItem(channelTuple);
+                    sLog.Debug("LSCProxyService", "JoinChannels: Added channel ID %d to result", channelID->value());
+                } else {
+                    sLog.Warning("LSCProxyService", "JoinChannels: Channel ID at index %zu is not an integer", i);
+                }
+            }
+        } else {
+            sLog.Warning("LSCProxyService", "JoinChannels: First argument is not a list");
+        }
+    } else {
+        sLog.Warning("LSCProxyService", "JoinChannels: No arguments provided");
+    }
+    
+    sLog.Debug("LSCProxyService", "JoinChannels: Returning %zu results", result->size());
+    return result;
 }
 
 PyResult LSCProxyService::LeaveChannels(PyCallArgs& call)
 {
     sLog.Debug("LSCProxyService", "LeaveChannels called - returning empty list");
+    return new PyList();
+}
+
+PyResult LSCProxyService::LeaveChannel(PyCallArgs& call)
+{
+    sLog.Debug("LSCProxyService", "LeaveChannel called - returning empty list");
     return new PyList();
 }
 

--- a/src/eve-server/lscproxy/LSCProxyService.cpp
+++ b/src/eve-server/lscproxy/LSCProxyService.cpp
@@ -1,0 +1,136 @@
+/*
+    ------------------------------------------------------------------------------------
+    LICENSE:
+    ------------------------------------------------------------------------------------
+    This file is part of EVEmu: EVE Online Server Emulator
+    Copyright 2006 - 2021 The EVEmu Team
+    For the latest information visit https://evemu.dev
+    ------------------------------------------------------------------------------------
+    This program is free software; you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License as published by the Free Software
+    Foundation; either version 2 of the License, or (at your option) any later
+    version.
+    This program is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+    FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+    You should have received a copy of the GNU Lesser General Public License along with
+    this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+    Place - Suite 330, Boston, MA 02111-1307, USA, or go to
+    http://www.gnu.org/copyleft/lesser.txt.
+    ------------------------------------------------------------------------------------
+    Author: Zhur
+*/
+
+#include "eve-server.h"
+
+#include "lscproxy/LSCProxyService.h"
+
+LSCProxyService::LSCProxyService() :
+    Service("lscProxy")
+{
+    this->Add("GetChannels", &LSCProxyService::GetChannels);
+    this->Add("JoinChannels", &LSCProxyService::JoinChannels);
+    this->Add("LeaveChannels", &LSCProxyService::LeaveChannels);
+    this->Add("CreateChannel", &LSCProxyService::CreateChannel);
+    this->Add("Configure", &LSCProxyService::Configure);
+    this->Add("DestroyChannel", &LSCProxyService::DestroyChannel);
+    this->Add("GetMembers", &LSCProxyService::GetMembers);
+    this->Add("GetMember", &LSCProxyService::GetMember);
+    this->Add("SendMessage", &LSCProxyService::SendMessage);
+    this->Add("Invite", &LSCProxyService::Invite);
+    this->Add("AccessControl", &LSCProxyService::AccessControl);
+    this->Add("GetMyMessages", &LSCProxyService::GetMyMessages);
+    this->Add("GetMessageDetails", &LSCProxyService::GetMessageDetails);
+    this->Add("Page", &LSCProxyService::Page);
+    this->Add("MarkMessagesRead", &LSCProxyService::MarkMessagesRead);
+}
+
+PyResult LSCProxyService::GetChannels(PyCallArgs& call)
+{
+    sLog.Debug("LSCProxyService", "GetChannels called - stub");
+    return new PyList();
+}
+
+PyResult LSCProxyService::JoinChannels(PyCallArgs& call)
+{
+    sLog.Debug("LSCProxyService", "JoinChannels called - returning empty list");
+    return new PyList();
+}
+
+PyResult LSCProxyService::LeaveChannels(PyCallArgs& call)
+{
+    sLog.Debug("LSCProxyService", "LeaveChannels called - returning empty list");
+    return new PyList();
+}
+
+PyResult LSCProxyService::CreateChannel(PyCallArgs& call)
+{
+    sLog.Debug("LSCProxyService", "CreateChannel called - stub");
+    return new PyInt(0);
+}
+
+PyResult LSCProxyService::Configure(PyCallArgs& call)
+{
+    sLog.Debug("LSCProxyService", "Configure called - stub");
+    return PyStatic.NewNone();
+}
+
+PyResult LSCProxyService::DestroyChannel(PyCallArgs& call)
+{
+    sLog.Debug("LSCProxyService", "DestroyChannel called - stub");
+    return PyStatic.NewNone();
+}
+
+PyResult LSCProxyService::GetMembers(PyCallArgs& call)
+{
+    sLog.Debug("LSCProxyService", "GetMembers called - stub");
+    return new PyList();
+}
+
+PyResult LSCProxyService::GetMember(PyCallArgs& call)
+{
+    sLog.Debug("LSCProxyService", "GetMember called - stub");
+    return PyStatic.NewNone();
+}
+
+PyResult LSCProxyService::SendMessage(PyCallArgs& call)
+{
+    sLog.Debug("LSCProxyService", "SendMessage called - stub");
+    return PyStatic.NewNone();
+}
+
+PyResult LSCProxyService::Invite(PyCallArgs& call)
+{
+    sLog.Debug("LSCProxyService", "Invite called - stub");
+    return PyStatic.NewNone();
+}
+
+PyResult LSCProxyService::AccessControl(PyCallArgs& call)
+{
+    sLog.Debug("LSCProxyService", "AccessControl called - stub");
+    return PyStatic.NewNone();
+}
+
+PyResult LSCProxyService::GetMyMessages(PyCallArgs& call)
+{
+    sLog.Debug("LSCProxyService", "GetMyMessages called - stub");
+    return new PyList();
+}
+
+PyResult LSCProxyService::GetMessageDetails(PyCallArgs& call)
+{
+    sLog.Debug("LSCProxyService", "GetMessageDetails called - stub");
+    return PyStatic.NewNone();
+}
+
+PyResult LSCProxyService::Page(PyCallArgs& call)
+{
+    sLog.Debug("LSCProxyService", "Page called - stub");
+    return PyStatic.NewNone();
+}
+
+PyResult LSCProxyService::MarkMessagesRead(PyCallArgs& call)
+{
+    sLog.Debug("LSCProxyService", "MarkMessagesRead called - stub");
+    return PyStatic.NewNone();
+}

--- a/src/eve-server/lscproxy/LSCProxyService.h
+++ b/src/eve-server/lscproxy/LSCProxyService.h
@@ -34,6 +34,7 @@ protected:
     PyResult GetChannels(PyCallArgs &call);
     PyResult JoinChannels(PyCallArgs &call);
     PyResult LeaveChannels(PyCallArgs &call);
+    PyResult LeaveChannel(PyCallArgs &call);
     PyResult CreateChannel(PyCallArgs &call);
     PyResult Configure(PyCallArgs &call);
     PyResult DestroyChannel(PyCallArgs &call);

--- a/src/eve-server/lscproxy/LSCProxyService.h
+++ b/src/eve-server/lscproxy/LSCProxyService.h
@@ -1,0 +1,51 @@
+/*
+    ------------------------------------------------------------------------------------
+    LICENSE:
+    ------------------------------------------------------------------------------------
+    This file is part of EVEmu: EVE Online Server Emulator
+    Copyright 2006 - 2021 The EVEmu Team
+    For the latest information visit https://evemu.dev
+    ------------------------------------------------------------------------------------
+    This program is free software; you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License as published by the Free Software
+    Foundation; either version 2 of the License, or (at your option) any later
+    version.
+    This program is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+    FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+    You should have received a copy of the GNU Lesser General Public License along with
+    this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+    Place - Suite 330, Boston, MA 02111-1307, USA, or go to
+    http://www.gnu.org/copyleft/lesser.txt.
+    ------------------------------------------------------------------------------------
+    Author: Zhur
+*/
+
+#ifndef __LSCPROXY_SERVICE_H_INCL__
+#define __LSCPROXY_SERVICE_H_INCL__
+
+#include "services/Service.h"
+
+class LSCProxyService : public Service <LSCProxyService> {
+public:
+    LSCProxyService();
+
+protected:
+    PyResult GetChannels(PyCallArgs &call);
+    PyResult JoinChannels(PyCallArgs &call);
+    PyResult LeaveChannels(PyCallArgs &call);
+    PyResult CreateChannel(PyCallArgs &call);
+    PyResult Configure(PyCallArgs &call);
+    PyResult DestroyChannel(PyCallArgs &call);
+    PyResult GetMembers(PyCallArgs &call);
+    PyResult GetMember(PyCallArgs &call);
+    PyResult SendMessage(PyCallArgs &call);
+    PyResult Invite(PyCallArgs &call);
+    PyResult AccessControl(PyCallArgs &call);
+    PyResult GetMyMessages(PyCallArgs &call);
+    PyResult GetMessageDetails(PyCallArgs &call);
+    PyResult Page(PyCallArgs &call);
+    PyResult MarkMessagesRead(PyCallArgs &call);
+};
+
+#endif

--- a/src/eve-server/map/MapService.cpp
+++ b/src/eve-server/map/MapService.cpp
@@ -58,6 +58,7 @@ MapService::MapService() :
     this->Add("GetAllianceJumpBridges", &MapService::GetAllianceJumpBridges);
     this->Add("GetAllianceBeacons", &MapService::GetAllianceBeacons);
     this->Add("GetCurrentSovData", &MapService::GetCurrentSovData);
+    this->Add("GetFacWarZoneInfo", &MapService::GetFacWarZoneInfo);
     // custom call for displaying all items in system
     this->Add ("GetCurrentEntities", &MapService::GetCurrentEntities);
 }
@@ -370,5 +371,13 @@ PyResult MapService::GetStuckSystems(PyCallArgs &call)
     res = tuple0;
 
     return res;
+}
+
+PyResult MapService::GetFacWarZoneInfo(PyCallArgs &call, PyInt* factionID)
+{
+    sLog.Warning( "MapService::Handle_GetFacWarZoneInfo()", "size=%lu", call.tuple->size());
+    call.Dump(SERVICE__CALL_DUMP);
+
+    return PyStatic.NewNone();
 }
 

--- a/src/eve-server/map/MapService.h
+++ b/src/eve-server/map/MapService.h
@@ -61,6 +61,7 @@ protected:
     PyResult GetIncursionGlobalReport(PyCallArgs& call);
     PyResult GetVictoryPoints(PyCallArgs& call);
     PyResult GetStuckSystems(PyCallArgs& call);
+    PyResult GetFacWarZoneInfo(PyCallArgs& call, PyInt* factionID);
 
 };
 

--- a/src/eve-server/missions/MissionDataMgr.cpp
+++ b/src/eve-server/missions/MissionDataMgr.cpp
@@ -285,6 +285,7 @@ void MissionDataMgr::Populate()
         offer.dungeonLocationID = row.GetInt(32);
         offer.dungeonSolarSystemID = row.GetInt(33);
         offer.dateCompleted = 0;
+        offer.contentID = 0;
         // will need to determine how to store/retrieve bookmarks as a list of dicts here
         offer.bookmarks = new PyList();
         m_offers.emplace(row.GetInt(2), offer);
@@ -335,6 +336,7 @@ void MissionDataMgr::Populate()
         offer.destinationSystemID = 0;
         offer.dungeonLocationID = 0;
         offer.dungeonSolarSystemID = 0;
+        offer.contentID = 0;
         offer.bookmarks = new PyList(); //invalid offers will not have bms
         m_xoffers.emplace(row.GetInt(2), offer);
     }
@@ -443,6 +445,7 @@ void MissionDataMgr::CreateMissionOffer(uint8 typeID, uint8 level, uint8 raceID,
     data.destinationSystemID    = 0;
     data.dungeonLocationID      = 0;
     data.dungeonSolarSystemID   = 0;
+    data.contentID              = 0;
     data.bookmarks              = new PyList();
 
     /** @todo  this will need to be adjusted for raceID eventually */

--- a/src/eve-server/projectdiscovery/ProjectDiscoveryService.cpp
+++ b/src/eve-server/projectdiscovery/ProjectDiscoveryService.cpp
@@ -1,0 +1,38 @@
+/*
+    ------------------------------------------------------------------------------------
+    LICENSE:
+    ------------------------------------------------------------------------------------
+    This file is part of EVEmu: EVE Online Server Emulator
+    Copyright 2006 - 2021 The EVEmu Team
+    For the latest information visit https://evemu.dev
+    ------------------------------------------------------------------------------------
+    This program is free software; you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License as published by the Free Software
+    Foundation; either version 2 of the License, or (at your option) any later
+    version.
+    This program is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+    FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+    You should have received a copy of the GNU Lesser General Public License along with
+    this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+    Place - Suite 330, Boston, MA 02111-1307, USA, or go to
+    http://www.gnu.org/copyleft/lesser.txt.
+    ------------------------------------------------------------------------------------
+    Author: Zhur
+*/
+
+#include "eve-server.h"
+
+#include "projectdiscovery/ProjectDiscoveryService.h"
+
+ProjectDiscoveryService::ProjectDiscoveryService() :
+    Service("ProjectDiscovery")
+{
+    this->Add("is_enabled", &ProjectDiscoveryService::is_enabled);
+}
+
+PyResult ProjectDiscoveryService::is_enabled(PyCallArgs& call)
+{
+    sLog.Debug("ProjectDiscoveryService", "is_enabled called - returning False");
+    return PyStatic.NewFalse();
+}

--- a/src/eve-server/projectdiscovery/ProjectDiscoveryService.h
+++ b/src/eve-server/projectdiscovery/ProjectDiscoveryService.h
@@ -1,0 +1,37 @@
+/*
+    ------------------------------------------------------------------------------------
+    LICENSE:
+    ------------------------------------------------------------------------------------
+    This file is part of EVEmu: EVE Online Server Emulator
+    Copyright 2006 - 2021 The EVEmu Team
+    For the latest information visit https://evemu.dev
+    ------------------------------------------------------------------------------------
+    This program is free software; you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License as published by the Free Software
+    Foundation; either version 2 of the License, or (at your option) any later
+    version.
+    This program is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+    FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+    You should have received a copy of the GNU Lesser General Public License along with
+    this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+    Place - Suite 330, Boston, MA 02111-1307, USA, or go to
+    http://www.gnu.org/copyleft/lesser.txt.
+    ------------------------------------------------------------------------------------
+    Author: Zhur
+*/
+
+#ifndef __PROJECTDISCOVERY_SERVICE_H_INCL__
+#define __PROJECTDISCOVERY_SERVICE_H_INCL__
+
+#include "services/Service.h"
+
+class ProjectDiscoveryService : public Service <ProjectDiscoveryService> {
+public:
+    ProjectDiscoveryService();
+
+protected:
+    PyResult is_enabled(PyCallArgs &call);
+};
+
+#endif

--- a/src/eve-server/seasonmanager/SeasonManagerService.cpp
+++ b/src/eve-server/seasonmanager/SeasonManagerService.cpp
@@ -33,6 +33,6 @@ SeasonManagerService::SeasonManagerService() :
 
 PyResult SeasonManagerService::get_current_season(PyCallArgs& call)
 {
-    sLog.Debug("SeasonManagerService", "get_current_season called - stub");
+    sLog.Debug("SeasonManagerService", "get_current_season called - returning None (no active season)");
     return PyStatic.NewNone();
 }

--- a/src/eve-server/seasonmanager/SeasonManagerService.cpp
+++ b/src/eve-server/seasonmanager/SeasonManagerService.cpp
@@ -1,0 +1,38 @@
+/*
+    ------------------------------------------------------------------------------------
+    LICENSE:
+    ------------------------------------------------------------------------------------
+    This file is part of EVEmu: EVE Online Server Emulator
+    Copyright 2006 - 2021 The EVEmu Team
+    For the latest information visit https://evemu.dev
+    ------------------------------------------------------------------------------------
+    This program is free software; you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License as published by the Free Software
+    Foundation; either version 2 of the License, or (at your option) any later
+    version.
+    This program is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+    FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+    You should have received a copy of the GNU Lesser General Public License along with
+    this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+    Place - Suite 330, Boston, MA 02111-1307, USA, or go to
+    http://www.gnu.org/copyleft/lesser.txt.
+    ------------------------------------------------------------------------------------
+    Author: Zhur
+*/
+
+#include "eve-server.h"
+
+#include "seasonmanager/SeasonManagerService.h"
+
+SeasonManagerService::SeasonManagerService() :
+    Service("seasonManager")
+{
+    this->Add("get_current_season", &SeasonManagerService::get_current_season);
+}
+
+PyResult SeasonManagerService::get_current_season(PyCallArgs& call)
+{
+    sLog.Debug("SeasonManagerService", "get_current_season called - stub");
+    return PyStatic.NewNone();
+}

--- a/src/eve-server/seasonmanager/SeasonManagerService.h
+++ b/src/eve-server/seasonmanager/SeasonManagerService.h
@@ -1,0 +1,37 @@
+/*
+    ------------------------------------------------------------------------------------
+    LICENSE:
+    ------------------------------------------------------------------------------------
+    This file is part of EVEmu: EVE Online Server Emulator
+    Copyright 2006 - 2021 The EVEmu Team
+    For the latest information visit https://evemu.dev
+    ------------------------------------------------------------------------------------
+    This program is free software; you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License as published by the Free Software
+    Foundation; either version 2 of the License, or (at your option) any later
+    version.
+    This program is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+    FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+    You should have received a copy of the GNU Lesser General Public License along with
+    this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+    Place - Suite 330, Boston, MA 02111-1307, USA, or go to
+    http://www.gnu.org/copyleft/lesser.txt.
+    ------------------------------------------------------------------------------------
+    Author: Zhur
+*/
+
+#ifndef __SEASONMANAGER_SERVICE_H_INCL__
+#define __SEASONMANAGER_SERVICE_H_INCL__
+
+#include "services/Service.h"
+
+class SeasonManagerService : public Service <SeasonManagerService> {
+public:
+    SeasonManagerService();
+
+protected:
+    PyResult get_current_season(PyCallArgs &call);
+};
+
+#endif

--- a/src/eve-server/services/BoundService.h
+++ b/src/eve-server/services/BoundService.h
@@ -108,10 +108,20 @@ public:
 
     PyResult MachoBindObject(PyCallArgs& args, PyRep* bindParameters, std::optional<PyTuple*> call) {
         // register the new instance in the service manager
+        codelog(SERVICE__MESSAGE, "%s Service: MachoBindObject called", this->GetName().c_str());
+        bindParameters->Dump(SERVICE__MESSAGE, "BindParameters: ");
+        if (call.has_value()) {
+            codelog(SERVICE__MESSAGE, "%s Service: MachoBindObject has call", this->GetName().c_str());
+            call.value()->Dump(SERVICE__MESSAGE, "Call: ");
+        } else {
+            codelog(SERVICE__MESSAGE, "%s Service: MachoBindObject has no call", this->GetName().c_str());
+        }
+
         BoundDispatcher* bound = this->BindObject(args.client, bindParameters);
 
         // binding failed for whatever reason, just return none and get on with our lifes
         if (bound == nullptr) {
+            codelog(SERVICE__ERROR, "%s Service: BindObject returned nullptr", this->GetName().c_str());
             return nullptr;
         }
 
@@ -127,8 +137,12 @@ public:
         rsp->SetItem(0, new PySubStruct(new PySubStream(bound->GetOID())));
 
         if (call.has_value() == false) {
+            codelog(SERVICE__MESSAGE, "%s Service: MachoBindObject has no call, returning None", this->GetName().c_str());
             rsp->SetItem(1, PyStatic.NewNone());
         } else {
+            codelog(SERVICE__MESSAGE, "%s Service: MachoBindObject has call, attempting to decode", this->GetName().c_str());
+            call.value()->Dump(SERVICE__MESSAGE, "Call value: ");
+            
             // dispatch call
             CallMachoBindObject_call boundcall;
 
@@ -141,7 +155,14 @@ public:
 
             PyCallArgs subArgs(args.client, boundcall.arguments, boundcall.dict_arguments);
 
+            _log(SERVICE__MESSAGE, "%s Service: Calling Dispatch for method '%s'", this->GetName().c_str(), boundcall.method_name.c_str());
             PyResult result = bound->Dispatch(boundcall.method_name, subArgs);
+            _log(SERVICE__MESSAGE, "%s Service: Dispatch returned", this->GetName().c_str());
+
+            _log(SERVICE__MESSAGE, "%s Service: Dispatch result ssResult is None? %s", this->GetName().c_str(), (result.ssResult->IsNone() ? "true" : "false"));
+            if (result.ssResult == nullptr) {
+                _log(SERVICE__ERROR, "%s Service: Dispatch result ssResult is nullptr!", this->GetName().c_str());
+            }
 
             // set the tuple data
             rsp->SetItem(1, result.ssResult);
@@ -150,7 +171,9 @@ public:
         }
 
         // return the response
-        return PyResult(rsp, byName);
+        PyResult finalResult(rsp, byName);
+        _log(SERVICE__MESSAGE, "%s Service: MachoBindObject returning final result", this->GetName().c_str());
+        return finalResult;
     }
 
 protected:

--- a/src/eve-server/ship/FighterMgrService.cpp
+++ b/src/eve-server/ship/FighterMgrService.cpp
@@ -20,50 +20,33 @@
     Place - Suite 330, Boston, MA 02111-1307, USA, or go to
     http://www.gnu.org/copyleft/lesser.txt.
     ------------------------------------------------------------------------------------
-    Author:        Zhur
+    Author:        EVEmu Team
 */
 
+#include "eve-server.h"
 
-#ifndef __INSURANCE_SERVICE_H_INCL__
-#define __INSURANCE_SERVICE_H_INCL__
+#include "ship/FighterMgrService.h"
 
-#include "ship/ShipDB.h"
-#include "services/BoundService.h"
-
-class InsuranceBound;
-
-class InsuranceService : public BindableService <InsuranceService, InsuranceBound> {
-public:
-    InsuranceService(EVEServiceManager& mgr);
-
-    void BoundReleased (InsuranceBound* bound) override;
-
-protected:
-    ShipDB m_db;
-
-    PyResult GetContractForShip(PyCallArgs& call, PyInt* shipID);
-    PyResult GetInsurancePrice(PyCallArgs& call, PyInt* typeID);
-    PyResult GetInsurancePrices(PyCallArgs& call, PyList* typeIDs);
-
-    BoundDispatcher* BindObject(Client *client, PyRep* bindParameters);
-};
-
-class InsuranceBound : public EVEBoundObject <InsuranceBound>
+FighterMgrService::FighterMgrService() :
+    Service("fighterMgr", eAccessLevel_Character)
 {
-public:
-    InsuranceBound(EVEServiceManager& mgr, InsuranceService& parent, ShipDB* db);
+    this->Add("GetFightersForShip", &FighterMgrService::GetFightersForShip);
+}
 
-protected:
-    PyResult InsureShip(PyCallArgs& call, PyInt* shipID, PyFloat* amount, std::optional<PyInt*> isCorporation);
-    PyResult UnInsureShip(PyCallArgs& call, PyInt* shipID);
-    PyResult GetContracts(PyCallArgs& call, std::optional<PyRep*> isCorporation);
-    PyResult GetInsurancePrice(PyCallArgs& call, PyInt* typeID);
+FighterMgrService::~FighterMgrService()
+{
+}
 
-protected:
-    ShipDB* m_db;
-    LSCService* m_lsc;
-};
+PyResult FighterMgrService::GetFightersForShip(PyCallArgs &call)
+{
+    _log(SERVICE__MESSAGE, "fighterMgr::GetFightersForShip called");
 
-#endif
-
-
+    PyList* fightersInTubes = new PyList();
+    PyList* fightersInSpace = new PyList();
+    
+    PyTuple* result = new PyTuple(2);
+    result->SetItem(0, fightersInTubes);
+    result->SetItem(1, fightersInSpace);
+    
+    return result;
+}

--- a/src/eve-server/ship/FighterMgrService.h
+++ b/src/eve-server/ship/FighterMgrService.h
@@ -20,50 +20,21 @@
     Place - Suite 330, Boston, MA 02111-1307, USA, or go to
     http://www.gnu.org/copyleft/lesser.txt.
     ------------------------------------------------------------------------------------
-    Author:        Zhur
+    Author:        EVEmu Team
 */
 
+#ifndef _FIGHTER_MGR_SERVICE_H
+#define _FIGHTER_MGR_SERVICE_H
 
-#ifndef __INSURANCE_SERVICE_H_INCL__
-#define __INSURANCE_SERVICE_H_INCL__
+#include "services/Service.h"
 
-#include "ship/ShipDB.h"
-#include "services/BoundService.h"
-
-class InsuranceBound;
-
-class InsuranceService : public BindableService <InsuranceService, InsuranceBound> {
+class FighterMgrService : public Service<FighterMgrService> {
 public:
-    InsuranceService(EVEServiceManager& mgr);
-
-    void BoundReleased (InsuranceBound* bound) override;
+    FighterMgrService();
+    virtual ~FighterMgrService();
 
 protected:
-    ShipDB m_db;
-
-    PyResult GetContractForShip(PyCallArgs& call, PyInt* shipID);
-    PyResult GetInsurancePrice(PyCallArgs& call, PyInt* typeID);
-    PyResult GetInsurancePrices(PyCallArgs& call, PyList* typeIDs);
-
-    BoundDispatcher* BindObject(Client *client, PyRep* bindParameters);
+    PyResult GetFightersForShip(PyCallArgs &call);
 };
 
-class InsuranceBound : public EVEBoundObject <InsuranceBound>
-{
-public:
-    InsuranceBound(EVEServiceManager& mgr, InsuranceService& parent, ShipDB* db);
-
-protected:
-    PyResult InsureShip(PyCallArgs& call, PyInt* shipID, PyFloat* amount, std::optional<PyInt*> isCorporation);
-    PyResult UnInsureShip(PyCallArgs& call, PyInt* shipID);
-    PyResult GetContracts(PyCallArgs& call, std::optional<PyRep*> isCorporation);
-    PyResult GetInsurancePrice(PyCallArgs& call, PyInt* typeID);
-
-protected:
-    ShipDB* m_db;
-    LSCService* m_lsc;
-};
-
-#endif
-
-
+#endif//_FIGHTER_MGR_SERVICE_H

--- a/src/eve-server/ship/ShipKillCounterService.cpp
+++ b/src/eve-server/ship/ShipKillCounterService.cpp
@@ -20,50 +20,27 @@
     Place - Suite 330, Boston, MA 02111-1307, USA, or go to
     http://www.gnu.org/copyleft/lesser.txt.
     ------------------------------------------------------------------------------------
-    Author:        Zhur
+    Author:        EVEmu Team
 */
 
+#include "eve-server.h"
 
-#ifndef __INSURANCE_SERVICE_H_INCL__
-#define __INSURANCE_SERVICE_H_INCL__
+#include "ship/ShipKillCounterService.h"
 
-#include "ship/ShipDB.h"
-#include "services/BoundService.h"
-
-class InsuranceBound;
-
-class InsuranceService : public BindableService <InsuranceService, InsuranceBound> {
-public:
-    InsuranceService(EVEServiceManager& mgr);
-
-    void BoundReleased (InsuranceBound* bound) override;
-
-protected:
-    ShipDB m_db;
-
-    PyResult GetContractForShip(PyCallArgs& call, PyInt* shipID);
-    PyResult GetInsurancePrice(PyCallArgs& call, PyInt* typeID);
-    PyResult GetInsurancePrices(PyCallArgs& call, PyList* typeIDs);
-
-    BoundDispatcher* BindObject(Client *client, PyRep* bindParameters);
-};
-
-class InsuranceBound : public EVEBoundObject <InsuranceBound>
+ShipKillCounterService::ShipKillCounterService() :
+    Service("shipKillCounter", eAccessLevel_Character)
 {
-public:
-    InsuranceBound(EVEServiceManager& mgr, InsuranceService& parent, ShipDB* db);
+    this->Add("GetItemKillCountPlayer", &ShipKillCounterService::GetItemKillCountPlayer);
+}
 
-protected:
-    PyResult InsureShip(PyCallArgs& call, PyInt* shipID, PyFloat* amount, std::optional<PyInt*> isCorporation);
-    PyResult UnInsureShip(PyCallArgs& call, PyInt* shipID);
-    PyResult GetContracts(PyCallArgs& call, std::optional<PyRep*> isCorporation);
-    PyResult GetInsurancePrice(PyCallArgs& call, PyInt* typeID);
+ShipKillCounterService::~ShipKillCounterService()
+{
+}
 
-protected:
-    ShipDB* m_db;
-    LSCService* m_lsc;
-};
+PyResult ShipKillCounterService::GetItemKillCountPlayer(PyCallArgs &call, PyInt* itemID)
+{
+    _log(SERVICE__MESSAGE, "shipKillCounter::GetItemKillCountPlayer called for item %u", 
+         itemID ? itemID->value() : 0);
 
-#endif
-
-
+    return new PyInt(0);
+}

--- a/src/eve-server/ship/ShipKillCounterService.h
+++ b/src/eve-server/ship/ShipKillCounterService.h
@@ -20,50 +20,21 @@
     Place - Suite 330, Boston, MA 02111-1307, USA, or go to
     http://www.gnu.org/copyleft/lesser.txt.
     ------------------------------------------------------------------------------------
-    Author:        Zhur
+    Author:        EVEmu Team
 */
 
+#ifndef _SHIP_KILL_COUNTER_SERVICE_H
+#define _SHIP_KILL_COUNTER_SERVICE_H
 
-#ifndef __INSURANCE_SERVICE_H_INCL__
-#define __INSURANCE_SERVICE_H_INCL__
+#include "services/Service.h"
 
-#include "ship/ShipDB.h"
-#include "services/BoundService.h"
-
-class InsuranceBound;
-
-class InsuranceService : public BindableService <InsuranceService, InsuranceBound> {
+class ShipKillCounterService : public Service<ShipKillCounterService> {
 public:
-    InsuranceService(EVEServiceManager& mgr);
-
-    void BoundReleased (InsuranceBound* bound) override;
+    ShipKillCounterService();
+    virtual ~ShipKillCounterService();
 
 protected:
-    ShipDB m_db;
-
-    PyResult GetContractForShip(PyCallArgs& call, PyInt* shipID);
-    PyResult GetInsurancePrice(PyCallArgs& call, PyInt* typeID);
-    PyResult GetInsurancePrices(PyCallArgs& call, PyList* typeIDs);
-
-    BoundDispatcher* BindObject(Client *client, PyRep* bindParameters);
+    PyResult GetItemKillCountPlayer(PyCallArgs &call, PyInt* itemID);
 };
 
-class InsuranceBound : public EVEBoundObject <InsuranceBound>
-{
-public:
-    InsuranceBound(EVEServiceManager& mgr, InsuranceService& parent, ShipDB* db);
-
-protected:
-    PyResult InsureShip(PyCallArgs& call, PyInt* shipID, PyFloat* amount, std::optional<PyInt*> isCorporation);
-    PyResult UnInsureShip(PyCallArgs& call, PyInt* shipID);
-    PyResult GetContracts(PyCallArgs& call, std::optional<PyRep*> isCorporation);
-    PyResult GetInsurancePrice(PyCallArgs& call, PyInt* typeID);
-
-protected:
-    ShipDB* m_db;
-    LSCService* m_lsc;
-};
-
-#endif
-
-
+#endif//_SHIP_KILL_COUNTER_SERVICE_H

--- a/src/eve-server/ship/ShipService.cpp
+++ b/src/eve-server/ship/ShipService.cpp
@@ -97,6 +97,7 @@ ShipBound::ShipBound (EVEServiceManager& mgr, ShipService& parent, ShipItem* shi
     this->Add("Jettison", &ShipBound::Jettison);
     this->Add("ConfigureShip", &ShipBound::ConfigureShip);
     this->Add("GetShipConfiguration", &ShipBound::GetShipConfiguration);
+    this->Add("GetDirtTimestamp", &ShipBound::GetDirtTimestamp);
     this->Add("SelfDestruct", &ShipBound::SelfDestruct);
     this->Add("BoardStoredShip", &ShipBound::BoardStoredShip);
     this->Add("StoreVessel", &ShipBound::StoreVessel);
@@ -253,11 +254,12 @@ PyResult ShipBound::ActivateShip(PyCallArgs &call, PyInt* newShipID, std::option
 
     pClient->BoardShip(newShipRef);
 
-    // response should return ship modules, loaded charges, and linked weapons
-    PyTuple* rsp = new PyTuple(3);
+    // response should return ship modules, loaded charges, linked weapons, and heat states
+    PyTuple* rsp = new PyTuple(4);
         rsp->SetItem(0, newShipRef->GetShipState());    //dict of ship modules
         rsp->SetItem(1, newShipRef->GetChargeState());    //dict of flagID/subLocation{loc, flag, typeID}
         rsp->SetItem(2, newShipRef->GetLinkedWeapons()); // dict of linked modules
+        rsp->SetItem(3, new PyList()); // heat states (empty for now)
     if (is_log_enabled(CLIENT__INFO))
         rsp->Dump(CLIENT__INFO, "    ");
     return rsp;
@@ -1202,6 +1204,14 @@ PyResult ShipBound::GetShipConfiguration(PyCallArgs &call)
     PyDict* dict = new PyDict();
     dict->SetItemString("allowFleetSMBUsage", new PyBool(call.client->GetShipSE()->GetFleetSMBUsage()));
     return dict;
+}
+
+PyResult ShipBound::GetDirtTimestamp(PyCallArgs &call, PyInt* itemID)
+{
+    _log(SERVICE__MESSAGE, "ShipBound::GetDirtTimestamp called for item %u", 
+         itemID ? itemID->value() : 0);
+
+    return new PyLong(0);
 }
 
 PyResult ShipBound::ConfigureShip(PyCallArgs &call, PyDict* configuration)

--- a/src/eve-server/ship/ShipService.h
+++ b/src/eve-server/ship/ShipService.h
@@ -68,6 +68,7 @@ protected:
     PyResult AssembleShip(PyCallArgs& call, PyList* itemIDs);
     PyResult GetShipConfiguration(PyCallArgs& call);
     PyResult ConfigureShip(PyCallArgs& call, PyDict* configuration);
+    PyResult GetDirtTimestamp(PyCallArgs& call, PyInt* itemID);
     PyResult LaunchFromContainer(PyCallArgs& call, PyInt* structureID, PyList* ids);
     PyResult ScoopToSMA(PyCallArgs& call, PyInt* objectID);
     PyResult BoardStoredShip(PyCallArgs& call, PyInt* structureID, PyInt* shipID);

--- a/src/eve-server/ship/ShipSkinMgrService.cpp
+++ b/src/eve-server/ship/ShipSkinMgrService.cpp
@@ -1,0 +1,78 @@
+/*
+    ------------------------------------------------------------------------------------
+    LICENSE:
+    ------------------------------------------------------------------------------------
+    This file is part of EVEmu: EVE Online Server Emulator
+    Copyright 2006 - 2021 The EVEmu Team
+    For the latest information visit https://evemu.dev
+    ------------------------------------------------------------------------------------
+    This program is free software; you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License as published by the Free Software
+    Foundation; either version 2 of the License, or (at your option) any later
+    version.
+
+    This program is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+    FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License along with
+    this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+    Place - Suite 330, Boston, MA 02111-1307, USA, or go to
+    http://www.gnu.org/copyleft/lesser.txt.
+    ------------------------------------------------------------------------------------
+    Author:        EVEmu Team
+*/
+
+#include "eve-server.h"
+
+#include "ship/ShipSkinMgrService.h"
+
+ShipSkinMgrService::ShipSkinMgrService() :
+    Service("shipSkinMgr", eAccessLevel_Character)
+{
+    this->Add("GetAppliedSkin", &ShipSkinMgrService::GetAppliedSkin);
+    this->Add("GetAppliedSkinMaterialSetID", &ShipSkinMgrService::GetAppliedSkinMaterialSetID);
+    this->Add("ActivateSkinLicense", &ShipSkinMgrService::ActivateSkinLicense);
+    this->Add("ApplySkin", &ShipSkinMgrService::ApplySkin);
+}
+
+ShipSkinMgrService::~ShipSkinMgrService()
+{
+}
+
+PyResult ShipSkinMgrService::GetAppliedSkin(PyCallArgs &call, PyInt* characterID, PyInt* itemID, PyInt* typeID)
+{
+    _log(SERVICE__MESSAGE, "shipSkinMgr::GetAppliedSkin called for character %u, item %u, type %u", 
+         characterID ? characterID->value() : 0, 
+         itemID ? itemID->value() : 0, 
+         typeID ? typeID->value() : 0);
+
+    return PyStatic.NewNone();
+}
+
+PyResult ShipSkinMgrService::GetAppliedSkinMaterialSetID(PyCallArgs &call, PyInt* characterID, PyInt* itemID, PyInt* typeID)
+{
+    _log(SERVICE__MESSAGE, "shipSkinMgr::GetAppliedSkinMaterialSetID called for character %u, item %u, type %u", 
+         characterID ? characterID->value() : 0, 
+         itemID ? itemID->value() : 0, 
+         typeID ? typeID->value() : 0);
+
+    return PyStatic.NewNone();
+}
+
+PyResult ShipSkinMgrService::ActivateSkinLicense(PyCallArgs &call, PyInt* itemID)
+{
+    _log(SERVICE__MESSAGE, "shipSkinMgr::ActivateSkinLicense called for item %u", 
+         itemID ? itemID->value() : 0);
+
+    return PyStatic.NewNone();
+}
+
+PyResult ShipSkinMgrService::ApplySkin(PyCallArgs &call, PyInt* itemID, PyInt* skinID)
+{
+    _log(SERVICE__MESSAGE, "shipSkinMgr::ApplySkin called for item %u, skin %u", 
+         itemID ? itemID->value() : 0, 
+         skinID ? skinID->value() : 0);
+
+    return PyStatic.NewNone();
+}

--- a/src/eve-server/ship/ShipSkinMgrService.h
+++ b/src/eve-server/ship/ShipSkinMgrService.h
@@ -20,50 +20,24 @@
     Place - Suite 330, Boston, MA 02111-1307, USA, or go to
     http://www.gnu.org/copyleft/lesser.txt.
     ------------------------------------------------------------------------------------
-    Author:        Zhur
+    Author:        EVEmu Team
 */
 
+#ifndef _SHIP_SKIN_MGR_SERVICE_H
+#define _SHIP_SKIN_MGR_SERVICE_H
 
-#ifndef __INSURANCE_SERVICE_H_INCL__
-#define __INSURANCE_SERVICE_H_INCL__
+#include "services/Service.h"
 
-#include "ship/ShipDB.h"
-#include "services/BoundService.h"
-
-class InsuranceBound;
-
-class InsuranceService : public BindableService <InsuranceService, InsuranceBound> {
+class ShipSkinMgrService : public Service<ShipSkinMgrService> {
 public:
-    InsuranceService(EVEServiceManager& mgr);
-
-    void BoundReleased (InsuranceBound* bound) override;
+    ShipSkinMgrService();
+    virtual ~ShipSkinMgrService();
 
 protected:
-    ShipDB m_db;
-
-    PyResult GetContractForShip(PyCallArgs& call, PyInt* shipID);
-    PyResult GetInsurancePrice(PyCallArgs& call, PyInt* typeID);
-    PyResult GetInsurancePrices(PyCallArgs& call, PyList* typeIDs);
-
-    BoundDispatcher* BindObject(Client *client, PyRep* bindParameters);
+    PyResult GetAppliedSkin(PyCallArgs &call, PyInt* characterID, PyInt* itemID, PyInt* typeID);
+    PyResult GetAppliedSkinMaterialSetID(PyCallArgs &call, PyInt* characterID, PyInt* itemID, PyInt* typeID);
+    PyResult ActivateSkinLicense(PyCallArgs &call, PyInt* itemID);
+    PyResult ApplySkin(PyCallArgs &call, PyInt* itemID, PyInt* skinID);
 };
 
-class InsuranceBound : public EVEBoundObject <InsuranceBound>
-{
-public:
-    InsuranceBound(EVEServiceManager& mgr, InsuranceService& parent, ShipDB* db);
-
-protected:
-    PyResult InsureShip(PyCallArgs& call, PyInt* shipID, PyFloat* amount, std::optional<PyInt*> isCorporation);
-    PyResult UnInsureShip(PyCallArgs& call, PyInt* shipID);
-    PyResult GetContracts(PyCallArgs& call, std::optional<PyRep*> isCorporation);
-    PyResult GetInsurancePrice(PyCallArgs& call, PyInt* typeID);
-
-protected:
-    ShipDB* m_db;
-    LSCService* m_lsc;
-};
-
-#endif
-
-
+#endif//_SHIP_SKIN_MGR_SERVICE_H

--- a/src/eve-server/skillmgr2/SkillHandler.cpp
+++ b/src/eve-server/skillmgr2/SkillHandler.cpp
@@ -1,0 +1,87 @@
+/*
+    ------------------------------------------------------------------------------------
+    LICENSE:
+    ------------------------------------------------------------------------------------
+    This file is part of EVEmu: EVE Online Server Emulator
+    Copyright 2006 - 2021 The EVEmu Team
+    For the latest information visit https://evemu.dev
+    ------------------------------------------------------------------------------------
+    This program is free software; you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License as published by the Free Software
+    Foundation; either version 2 of the License, or (at your option) any later
+    version.
+    This program is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+    FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+    You should have received a copy of the GNU Lesser General Public License along with
+    this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+    Place - Suite 330, Boston, MA 02111-1307, USA, or go to
+    http://www.gnu.org/copyleft/lesser.txt.
+    ------------------------------------------------------------------------------------
+    Author: Zhur
+*/
+
+#include "eve-server.h"
+
+#include "skillmgr2/SkillHandler.h"
+#include "skillmgr2/SkillMgr2Service.h"
+
+SkillHandler::SkillHandler(EVEServiceManager& mgr, SkillMgr2Service& parent) :
+    EVEBoundObject<SkillHandler>(mgr, parent),
+    m_parent(parent)
+{
+    this->Add("GetSkills", &SkillHandler::GetSkills);
+    this->Add("GetAttributes", &SkillHandler::GetAttributes);
+}
+
+PyResult SkillHandler::GetSkills(PyCallArgs& call)
+{
+    sLog.Debug("SkillHandler", "GetSkills called - returning character skills");
+    
+    CharacterRef cref = call.client->GetChar();
+    if (!cref) {
+        sLog.Error("SkillHandler", "GetSkills: No character found for client %u", call.client->GetCharacterID());
+        return PyStatic.NewNone();
+    }
+    
+    PyDict* skills = new PyDict();
+    
+    std::vector<InventoryItemRef> skillList;
+    cref->GetSkillsList(skillList);
+    
+    for (auto skillItem : skillList) {
+        if (!skillItem) continue;
+        
+        uint32 typeID = skillItem->typeID();
+        uint32 level = skillItem->GetAttribute(AttrSkillLevel).get_uint32();
+        int64 points = skillItem->GetAttribute(AttrSkillPoints).get_int();
+        
+        PyDict* skillInfo = new PyDict();
+        skillInfo->SetItem("skillLevel", new PyInt((int32)level));
+        skillInfo->SetItem("skillPoints", new PyLong(points));
+        
+        skills->SetItem(new PyInt(typeID), skillInfo);
+    }
+    
+    return skills;
+}
+
+PyResult SkillHandler::GetAttributes(PyCallArgs& call)
+{
+    sLog.Debug("SkillHandler", "GetAttributes called - returning character attributes");
+    
+    CharacterRef cref = call.client->GetChar();
+    if (!cref) {
+        sLog.Error("SkillHandler", "GetAttributes: No character found for client %u", call.client->GetCharacterID());
+        return PyStatic.NewNone();
+    }
+    
+    PyDict* attrs = new PyDict();
+    attrs->SetItem(new PyString("intelligence"), cref->GetAttribute(AttrIntelligence).GetPyObject());
+    attrs->SetItem(new PyString("perception"), cref->GetAttribute(AttrPerception).GetPyObject());
+    attrs->SetItem(new PyString("charisma"), cref->GetAttribute(AttrCharisma).GetPyObject());
+    attrs->SetItem(new PyString("willpower"), cref->GetAttribute(AttrWillpower).GetPyObject());
+    attrs->SetItem(new PyString("memory"), cref->GetAttribute(AttrMemory).GetPyObject());
+    
+    return attrs;
+}

--- a/src/eve-server/skillmgr2/SkillHandler.cpp
+++ b/src/eve-server/skillmgr2/SkillHandler.cpp
@@ -55,12 +55,14 @@ PyResult SkillHandler::GetSkills(PyCallArgs& call)
         uint32 typeID = skillItem->typeID();
         uint32 level = skillItem->GetAttribute(AttrSkillLevel).get_uint32();
         int64 points = skillItem->GetAttribute(AttrSkillPoints).get_int();
+        float rank = skillItem->GetAttribute(AttrSkillTimeConstant).get_float();
         
         PyDict* skillInfo = new PyDict();
         skillInfo->SetItem("skillLevel", new PyInt((int32)level));
         skillInfo->SetItem("skillPoints", new PyLong(points));
+        skillInfo->SetItem("skillRank", new PyFloat(rank));
         
-        skills->SetItem(new PyInt(typeID), skillInfo);
+        skills->SetItem(new PyInt(typeID), new PyObject("util.KeyVal", skillInfo));
     }
     
     return skills;

--- a/src/eve-server/skillmgr2/SkillHandler.cpp
+++ b/src/eve-server/skillmgr2/SkillHandler.cpp
@@ -32,6 +32,8 @@ SkillHandler::SkillHandler(EVEServiceManager& mgr, SkillMgr2Service& parent) :
 {
     this->Add("GetSkills", &SkillHandler::GetSkills);
     this->Add("GetAttributes", &SkillHandler::GetAttributes);
+    this->Add("GetSkillQueueAndFreePoints", &SkillHandler::GetSkillQueueAndFreePoints);
+    this->Add("GetSkillHistory", &SkillHandler::GetSkillHistory);
 }
 
 PyResult SkillHandler::GetSkills(PyCallArgs& call)
@@ -86,4 +88,41 @@ PyResult SkillHandler::GetAttributes(PyCallArgs& call)
     attrs->SetItem(new PyString("memory"), cref->GetAttribute(AttrMemory).GetPyObject());
     
     return attrs;
+}
+
+PyResult SkillHandler::GetSkillQueueAndFreePoints(PyCallArgs& call)
+{
+    sLog.Debug("SkillHandler", "GetSkillQueueAndFreePoints called - returning skill queue");
+    
+    CharacterRef cref = call.client->GetChar();
+    if (!cref) {
+        sLog.Error("SkillHandler", "GetSkillQueueAndFreePoints: No character found for client %u", call.client->GetCharacterID());
+        PyTuple* result = new PyTuple(2);
+        result->SetItem(0, new PyList());
+        result->SetItem(1, new PyLong(0));
+        return result;
+    }
+    
+    return cref->SendSkillQueue();
+}
+
+PyResult SkillHandler::GetSkillHistory(PyCallArgs& call)
+{
+    sLog.Debug("SkillHandler", "GetSkillHistory called - returning skill history");
+    
+    CharacterRef cref = call.client->GetChar();
+    if (!cref) {
+        sLog.Error("SkillHandler", "GetSkillHistory: No character found for client %u", call.client->GetCharacterID());
+        PyList* result = new PyList();
+        return result;
+    }
+    
+    PyRep* history = cref->GetSkillHistory();
+    if (!history) {
+        sLog.Warning("SkillHandler", "GetSkillHistory: No skill history found for character %u", call.client->GetCharacterID());
+        PyList* result = new PyList();
+        return result;
+    }
+    
+    return history;
 }

--- a/src/eve-server/skillmgr2/SkillHandler.h
+++ b/src/eve-server/skillmgr2/SkillHandler.h
@@ -35,6 +35,8 @@ public:
 protected:
     PyResult GetSkills(PyCallArgs& call);
     PyResult GetAttributes(PyCallArgs& call);
+    PyResult GetSkillQueueAndFreePoints(PyCallArgs& call);
+    PyResult GetSkillHistory(PyCallArgs& call);
 
 private:
     SkillMgr2Service& m_parent;

--- a/src/eve-server/skillmgr2/SkillHandler.h
+++ b/src/eve-server/skillmgr2/SkillHandler.h
@@ -1,0 +1,43 @@
+/*
+    ------------------------------------------------------------------------------------
+    LICENSE:
+    ------------------------------------------------------------------------------------
+    This file is part of EVEmu: EVE Online Server Emulator
+    Copyright 2006 - 2021 The EVEmu Team
+    For the latest information visit https://evemu.dev
+    ------------------------------------------------------------------------------------
+    This program is free software; you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License as published by the Free Software
+    Foundation; either version 2 of the License, or (at your option) any later
+    version.
+    This program is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+    FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+    You should have received a copy of the GNU Lesser General Public License along with
+    this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+    Place - Suite 330, Boston, MA 02111-1307, USA, or go to
+    http://www.gnu.org/copyleft/lesser.txt.
+    ------------------------------------------------------------------------------------
+    Author: Zhur
+*/
+
+#ifndef __SKILL_HANDLER_H_INCL__
+#define __SKILL_HANDLER_H_INCL__
+
+#include "services/BoundService.h"
+
+class SkillMgr2Service;
+
+class SkillHandler : public EVEBoundObject<SkillHandler> {
+public:
+    SkillHandler(EVEServiceManager& mgr, SkillMgr2Service& parent);
+
+protected:
+    PyResult GetSkills(PyCallArgs& call);
+    PyResult GetAttributes(PyCallArgs& call);
+
+private:
+    SkillMgr2Service& m_parent;
+};
+
+#endif

--- a/src/eve-server/skillmgr2/SkillMgr2Service.cpp
+++ b/src/eve-server/skillmgr2/SkillMgr2Service.cpp
@@ -51,8 +51,26 @@ BoundDispatcher* SkillMgr2Service::BindObject(Client* client, PyRep* bindParamet
 
 PyResult SkillMgr2Service::GetMySkillHandler(PyCallArgs& call)
 {
-    sLog.Debug("SkillMgr2Service", "GetMySkillHandler called - returning None (binding handled by MachoBindObject)");
-    return PyStatic.NewNone();
+    sLog.Debug("SkillMgr2Service", "GetMySkillHandler called - creating bound object");
+    
+    PyRep* bindParameters = new PyNone();
+    
+    BoundDispatcher* bound = this->BindObject(call.client, bindParameters);
+    
+    if (bound == nullptr) {
+        sLog.Error("SkillMgr2Service", "BindObject returned nullptr");
+        return PyStatic.NewNone();
+    }
+    
+    bound->NewReference(call.client);
+    
+    PyDict* byName = new PyDict();
+    byName->SetItem("OID+", bound->GetOID());
+    
+    PySubStruct* subStruct = new PySubStruct(new PySubStream(bound->GetOID()));
+    
+    PyResult result(subStruct, byName);
+    return result;
 }
 
 PyResult SkillMgr2Service::GetSkills(PyCallArgs& call)

--- a/src/eve-server/skillmgr2/SkillMgr2Service.cpp
+++ b/src/eve-server/skillmgr2/SkillMgr2Service.cpp
@@ -1,0 +1,102 @@
+/*
+    ------------------------------------------------------------------------------------
+    LICENSE:
+    ------------------------------------------------------------------------------------
+    This file is part of EVEmu: EVE Online Server Emulator
+    Copyright 2006 - 2021 The EVEmu Team
+    For the latest information visit https://evemu.dev
+    ------------------------------------------------------------------------------------
+    This program is free software; you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License as published by the Free Software
+    Foundation; either version 2 of the License, or (at your option) any later
+    version.
+    This program is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+    FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+    You should have received a copy of the GNU Lesser General Public License along with
+    this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+    Place - Suite 330, Boston, MA 02111-1307, USA, or go to
+    http://www.gnu.org/copyleft/lesser.txt.
+    ------------------------------------------------------------------------------------
+    Author: Zhur
+*/
+
+#include "eve-server.h"
+
+#include "skillmgr2/SkillMgr2Service.h"
+#include "skillmgr2/SkillHandler.h"
+
+SkillMgr2Service::SkillMgr2Service(EVEServiceManager& mgr) :
+    BindableService("skillMgr2", mgr)
+{
+    this->Add("GetMySkillHandler", &SkillMgr2Service::GetMySkillHandler);
+    this->Add("GetSkills", &SkillMgr2Service::GetSkills);
+    this->Add("GetSkillPoints", &SkillMgr2Service::GetSkillPoints);
+    this->Add("GetSkillQueueAndFreePoints", &SkillMgr2Service::GetSkillQueueAndFreePoints);
+    this->Add("GetFreeSkillPoints", &SkillMgr2Service::GetFreeSkillPoints);
+    this->Add("CheckAndSendNotifications", &SkillMgr2Service::CheckAndSendNotifications);
+    this->Add("GetBoosters", &SkillMgr2Service::GetBoosters);
+}
+
+void SkillMgr2Service::BoundReleased(SkillHandler* bound)
+{
+    sLog.Debug("SkillMgr2Service", "BoundReleased called");
+}
+
+BoundDispatcher* SkillMgr2Service::BindObject(Client* client, PyRep* bindParameters)
+{
+    sLog.Debug("SkillMgr2Service", "BindObject called");
+    return new SkillHandler(this->GetServiceManager(), *this);
+}
+
+PyResult SkillMgr2Service::GetMySkillHandler(PyCallArgs& call)
+{
+    sLog.Debug("SkillMgr2Service", "GetMySkillHandler called - returning None (binding handled by MachoBindObject)");
+    return PyStatic.NewNone();
+}
+
+PyResult SkillMgr2Service::GetSkills(PyCallArgs& call)
+{
+    sLog.Debug("SkillMgr2Service", "GetSkills called - stub");
+    PyTuple* result = new PyTuple(2);
+    result->SetItem(0, new PyLong(0));
+    result->SetItem(1, new PyLong(0));
+    return result;
+}
+
+PyResult SkillMgr2Service::GetSkillPoints(PyCallArgs& call)
+{
+    sLog.Debug("SkillMgr2Service", "GetSkillPoints called - stub");
+    PyTuple* result = new PyTuple(2);
+    result->SetItem(0, new PyLong(0));
+    result->SetItem(1, new PyLong(0));
+    return result;
+}
+
+PyResult SkillMgr2Service::GetSkillQueueAndFreePoints(PyCallArgs& call)
+{
+    sLog.Debug("SkillMgr2Service", "GetSkillQueueAndFreePoints called - returning empty queue and 0 free points");
+    PyTuple* result = new PyTuple(2);
+    result->SetItem(0, new PyList());
+    result->SetItem(1, new PyLong(0));
+    return result;
+}
+
+PyResult SkillMgr2Service::GetFreeSkillPoints(PyCallArgs& call)
+{
+    sLog.Debug("SkillMgr2Service", "GetFreeSkillPoints called - returning 0");
+    return new PyLong(0);
+}
+
+PyResult SkillMgr2Service::CheckAndSendNotifications(PyCallArgs& call)
+{
+    sLog.Debug("SkillMgr2Service", "CheckAndSendNotifications called - stub");
+    return PyStatic.NewNone();
+}
+
+PyResult SkillMgr2Service::GetBoosters(PyCallArgs& call)
+{
+    sLog.Debug("SkillMgr2Service", "GetBoosters called - returning empty dict");
+    PyDict* result = new PyDict();
+    return result;
+}

--- a/src/eve-server/skillmgr2/SkillMgr2Service.h
+++ b/src/eve-server/skillmgr2/SkillMgr2Service.h
@@ -1,0 +1,50 @@
+/*
+    ------------------------------------------------------------------------------------
+    LICENSE:
+    ------------------------------------------------------------------------------------
+    This file is part of EVEmu: EVE Online Server Emulator
+    Copyright 2006 - 2021 The EVEmu Team
+    For the latest information visit https://evemu.dev
+    ------------------------------------------------------------------------------------
+    This program is free software; you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License as published by the Free Software
+    Foundation; either version 2 of the License, or (at your option) any later
+    version.
+    This program is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+    FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+    You should have received a copy of the GNU Lesser General Public License along with
+    this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+    Place - Suite 330, Boston, MA 02111-1307, USA, or go to
+    http://www.gnu.org/copyleft/lesser.txt.
+    ------------------------------------------------------------------------------------
+    Author: Zhur
+*/
+
+#ifndef __SKILLMGR2_SERVICE_H_INCL__
+#define __SKILLMGR2_SERVICE_H_INCL__
+
+#include "services/BoundService.h"
+#include "services/ServiceManager.h"
+#include "Client.h"
+
+class SkillHandler;
+
+class SkillMgr2Service : public BindableService<SkillMgr2Service, SkillHandler> {
+public:
+    SkillMgr2Service(EVEServiceManager& mgr);
+
+    void BoundReleased(SkillHandler* bound) override;
+
+protected:
+    BoundDispatcher* BindObject(Client* client, PyRep* bindParameters) override;
+    PyResult GetMySkillHandler(PyCallArgs& call);
+    PyResult GetSkills(PyCallArgs& call);
+    PyResult GetSkillPoints(PyCallArgs& call);
+    PyResult GetSkillQueueAndFreePoints(PyCallArgs& call);
+    PyResult GetFreeSkillPoints(PyCallArgs& call);
+    PyResult CheckAndSendNotifications(PyCallArgs& call);
+    PyResult GetBoosters(PyCallArgs& call);
+};
+
+#endif

--- a/src/eve-server/station/InsuranceService.cpp
+++ b/src/eve-server/station/InsuranceService.cpp
@@ -45,7 +45,7 @@ InsuranceService::InsuranceService(EVEServiceManager& mgr) :
 {
     this->Add("GetContractForShip", &InsuranceService::GetContractForShip);
     this->Add("GetInsurancePrice", &InsuranceService::GetInsurancePrice);
-	//SetSessionCheck?
+    this->Add("GetInsurancePrices", &InsuranceService::GetInsurancePrices);
 }
 
 BoundDispatcher* InsuranceService::BindObject(Client* client, PyRep* bindParameters) {
@@ -67,6 +67,25 @@ PyResult InsuranceService::GetInsurancePrice(PyCallArgs& call, PyInt* typeID) {
         return new PyFloat(type->basePrice());
 
     return PyStatic.NewZero();
+}
+
+PyResult InsuranceService::GetInsurancePrices(PyCallArgs& call, PyList* typeIDs) {
+    /* called when docked to get prices for multiple ship types */
+    PyDict* result = new PyDict();
+    
+    if (typeIDs != nullptr) {
+        for (size_t i = 0; i < typeIDs->size(); ++i) {
+            PyInt* typeID = typeIDs->GetItem(i)->AsInt();
+            if (typeID != nullptr) {
+                const ItemType* type = sItemFactory.GetType(typeID->value());
+                if (type != nullptr) {
+                    result->SetItem(new PyInt(typeID->value()), new PyFloat(type->basePrice()));
+                }
+            }
+        }
+    }
+    
+    return result;
 }
 
 InsuranceBound::InsuranceBound(EVEServiceManager& mgr, InsuranceService& parent, ShipDB* db) :

--- a/src/eve-server/structuredirectory/StructureDirectoryService.cpp
+++ b/src/eve-server/structuredirectory/StructureDirectoryService.cpp
@@ -26,7 +26,7 @@
 #include "structuredirectory/StructureDirectoryService.h"
 
 StructureDirectoryService::StructureDirectoryService() :
-    Service("structureDirectory")
+    Service<StructureDirectoryService>("structureDirectory")
 {
     this->Add("GetMyDockableStructures", &StructureDirectoryService::GetMyDockableStructures);
     this->Add("GetStructuresInSystem", &StructureDirectoryService::GetStructuresInSystem);
@@ -35,18 +35,24 @@ StructureDirectoryService::StructureDirectoryService() :
 
 PyResult StructureDirectoryService::GetMyDockableStructures(PyCallArgs& call)
 {
-    sLog.Debug("StructureDirectoryService", "GetMyDockableStructures called - stub");
-    return new PyList();
+    sLog.Debug("StructureDirectoryService", "GetMyDockableStructures called");
+    
+    PyList* list = new PyList();
+    sLog.Debug("StructureDirectoryService", "GetMyDockableStructures: Returning empty list with %zu items", list->size());
+    
+    return list;
 }
 
 PyResult StructureDirectoryService::GetStructuresInSystem(PyCallArgs& call)
 {
     sLog.Debug("StructureDirectoryService", "GetStructuresInSystem called - returning empty list");
-    return new PyList();
+    PyList* list = new PyList();
+    return list;
 }
 
 PyResult StructureDirectoryService::GetStructureMapData(PyCallArgs& call)
 {
     sLog.Debug("StructureDirectoryService", "GetStructureMapData called - returning empty list");
-    return new PyList();
+    PyList* list = new PyList();
+    return list;
 }

--- a/src/eve-server/structuredirectory/StructureDirectoryService.cpp
+++ b/src/eve-server/structuredirectory/StructureDirectoryService.cpp
@@ -1,0 +1,38 @@
+/*
+    ------------------------------------------------------------------------------------
+    LICENSE:
+    ------------------------------------------------------------------------------------
+    This file is part of EVEmu: EVE Online Server Emulator
+    Copyright 2006 - 2021 The EVEmu Team
+    For the latest information visit https://evemu.dev
+    ------------------------------------------------------------------------------------
+    This program is free software; you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License as published by the Free Software
+    Foundation; either version 2 of the License, or (at your option) any later
+    version.
+    This program is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+    FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+    You should have received a copy of the GNU Lesser General Public License along with
+    this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+    Place - Suite 330, Boston, MA 02111-1307, USA, or go to
+    http://www.gnu.org/copyleft/lesser.txt.
+    ------------------------------------------------------------------------------------
+    Author: Zhur
+*/
+
+#include "eve-server.h"
+
+#include "structuredirectory/StructureDirectoryService.h"
+
+StructureDirectoryService::StructureDirectoryService() :
+    Service("structureDirectory")
+{
+    this->Add("GetMyDockableStructures", &StructureDirectoryService::GetMyDockableStructures);
+}
+
+PyResult StructureDirectoryService::GetMyDockableStructures(PyCallArgs& call)
+{
+    sLog.Debug("StructureDirectoryService", "GetMyDockableStructures called - stub");
+    return new PyList();
+}

--- a/src/eve-server/structuredirectory/StructureDirectoryService.cpp
+++ b/src/eve-server/structuredirectory/StructureDirectoryService.cpp
@@ -29,10 +29,24 @@ StructureDirectoryService::StructureDirectoryService() :
     Service("structureDirectory")
 {
     this->Add("GetMyDockableStructures", &StructureDirectoryService::GetMyDockableStructures);
+    this->Add("GetStructuresInSystem", &StructureDirectoryService::GetStructuresInSystem);
+    this->Add("GetStructureMapData", &StructureDirectoryService::GetStructureMapData);
 }
 
 PyResult StructureDirectoryService::GetMyDockableStructures(PyCallArgs& call)
 {
     sLog.Debug("StructureDirectoryService", "GetMyDockableStructures called - stub");
+    return new PyList();
+}
+
+PyResult StructureDirectoryService::GetStructuresInSystem(PyCallArgs& call)
+{
+    sLog.Debug("StructureDirectoryService", "GetStructuresInSystem called - returning empty list");
+    return new PyList();
+}
+
+PyResult StructureDirectoryService::GetStructureMapData(PyCallArgs& call)
+{
+    sLog.Debug("StructureDirectoryService", "GetStructureMapData called - returning empty list");
     return new PyList();
 }

--- a/src/eve-server/structuredirectory/StructureDirectoryService.h
+++ b/src/eve-server/structuredirectory/StructureDirectoryService.h
@@ -32,6 +32,8 @@ public:
 
 protected:
     PyResult GetMyDockableStructures(PyCallArgs &call);
+    PyResult GetStructuresInSystem(PyCallArgs &call);
+    PyResult GetStructureMapData(PyCallArgs &call);
 };
 
 #endif

--- a/src/eve-server/structuredirectory/StructureDirectoryService.h
+++ b/src/eve-server/structuredirectory/StructureDirectoryService.h
@@ -1,0 +1,37 @@
+/*
+    ------------------------------------------------------------------------------------
+    LICENSE:
+    ------------------------------------------------------------------------------------
+    This file is part of EVEmu: EVE Online Server Emulator
+    Copyright 2006 - 2021 The EVEmu Team
+    For the latest information visit https://evemu.dev
+    ------------------------------------------------------------------------------------
+    This program is free software; you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License as published by the Free Software
+    Foundation; either version 2 of the License, or (at your option) any later
+    version.
+    This program is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+    FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+    You should have received a copy of the GNU Lesser General Public License along with
+    this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+    Place - Suite 330, Boston, MA 02111-1307, USA, or go to
+    http://www.gnu.org/copyleft/lesser.txt.
+    ------------------------------------------------------------------------------------
+    Author: Zhur
+*/
+
+#ifndef __STRUCTUREDIRECTORY_SERVICE_H_INCL__
+#define __STRUCTUREDIRECTORY_SERVICE_H_INCL__
+
+#include "services/Service.h"
+
+class StructureDirectoryService : public Service <StructureDirectoryService> {
+public:
+    StructureDirectoryService();
+
+protected:
+    PyResult GetMyDockableStructures(PyCallArgs &call);
+};
+
+#endif

--- a/src/eve-server/structuresettings/StructureSettingsService.cpp
+++ b/src/eve-server/structuresettings/StructureSettingsService.cpp
@@ -1,0 +1,38 @@
+/*
+    ------------------------------------------------------------------------------------
+    LICENSE:
+    ------------------------------------------------------------------------------------
+    This file is part of EVEmu: EVE Online Server Emulator
+    Copyright 2006 - 2021 The EVEmu Team
+    For the latest information visit https://evemu.dev
+    ------------------------------------------------------------------------------------
+    This program is free software; you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License as published by the Free Software
+    Foundation; either version 2 of the License, or (at your option) any later
+    version.
+    This program is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+    FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+    You should have received a copy of the GNU Lesser General Public License along with
+    this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+    Place - Suite 330, Boston, MA 02111-1307, USA, or go to
+    http://www.gnu.org/copyleft/lesser.txt.
+    ------------------------------------------------------------------------------------
+    Author: Zhur
+*/
+
+#include "eve-server.h"
+
+#include "structuresettings/StructureSettingsService.h"
+
+StructureSettingsService::StructureSettingsService() :
+    Service("structureSettings")
+{
+    this->Add("CharacterGetServices", &StructureSettingsService::CharacterGetServices);
+}
+
+PyResult StructureSettingsService::CharacterGetServices(PyCallArgs& call)
+{
+    sLog.Debug("StructureSettingsService", "CharacterGetServices called - stub");
+    return new PyList();
+}

--- a/src/eve-server/structuresettings/StructureSettingsService.h
+++ b/src/eve-server/structuresettings/StructureSettingsService.h
@@ -1,0 +1,37 @@
+/*
+    ------------------------------------------------------------------------------------
+    LICENSE:
+    ------------------------------------------------------------------------------------
+    This file is part of EVEmu: EVE Online Server Emulator
+    Copyright 2006 - 2021 The EVEmu Team
+    For the latest information visit https://evemu.dev
+    ------------------------------------------------------------------------------------
+    This program is free software; you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License as published by the Free Software
+    Foundation; either version 2 of the License, or (at your option) any later
+    version.
+    This program is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+    FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+    You should have received a copy of the GNU Lesser General Public License along with
+    this program; if not, write to the Free Software Foundation, Inc., 59 Temple
+    Place - Suite 330, Boston, MA 02111-1307, USA, or go to
+    http://www.gnu.org/copyleft/lesser.txt.
+    ------------------------------------------------------------------------------------
+    Author: Zhur
+*/
+
+#ifndef __STRUCTURESETTINGS_SERVICE_H_INCL__
+#define __STRUCTURESETTINGS_SERVICE_H_INCL__
+
+#include "services/Service.h"
+
+class StructureSettingsService : public Service <StructureSettingsService> {
+public:
+    StructureSettingsService();
+
+protected:
+    PyResult CharacterGetServices(PyCallArgs &call);
+};
+
+#endif


### PR DESCRIPTION
Save coordinates when logging out: In WarpOut(), get the current precise coordinates of the ship, and then call m_ship->SaveShip() to save them to the database.

Database saving mechanism: SaveShip() calls ItemDB::SaveItem(), which saves the coordinates (x, y, z) of the ship to the corresponding fields of the entity table.
Restore on next login: When the character logs in next time, the system will read the saved coordinates of the ship from the database instead of using the default point or random point.

## Summary by Sourcery

Persist ship position on logout and use it to avoid unnecessary login warp when the ship is already near its saved location.

Enhancements:
- Introduce a shared SaveLocationData helper to persist ship position, custom info, and offline state in a single place.
- Adjust login warp logic to compare current and saved positions and skip warp when within a small distance threshold.
- Use the ship's actual saved position instead of a random point as the login warp target and improve bubble/state handling when no warp is needed.
- Guard ship logout calls to avoid null dereferences and add character location updates on logout for valid solar systems.