### PR TITLE
Fixed Incorrect Belt-Rat Spawn Class and Warp-in

### DIFF
--- a/src/eve-server/system/DestinyManager.cpp
+++ b/src/eve-server/system/DestinyManager.cpp
@@ -225,7 +225,14 @@ void DestinyManager::ProcessState() {
             float dot = toVec.dotProduct(m_shipHeading);
             float degrees = EvE::Trig::Rad2Deg(std::acos(dot));
 
-            if ((degrees < WARP_ALIGNMENT) and (m_timeFraction > 0.749)) {
+            if (mySE->IsNPCSE() && mySE->SysBubble()->CountPlayers() <= 0)
+            {
+                // this is an NPC that was spawned off-grid - nobody will ever see it, so just warp it in so it doesn't get disposed randomly
+                m_shipHeading = toVec;
+                InitWarp();
+                return;
+            } else if ((degrees < WARP_ALIGNMENT) and (m_timeFraction > 0.749)) {
+                // entering warp from here is the happy path for most cases
                 m_shipHeading = toVec;
                 InitWarp();
                 return;

--- a/src/eve-server/system/cosmicMgrs/SpawnMgr.cpp
+++ b/src/eve-server/system/cosmicMgrs/SpawnMgr.cpp
@@ -833,8 +833,7 @@ void SpawnMgr::MakeSpawn(SystemBubble* pBubble, uint32 factionID, uint8 sClass, 
             m_system->AddNPC(pNPC);
 
             pNPC->DestinyMgr()->SetPosition(startPos);
-            //  begin warp.  this may have to be looked into later for timing of large spawns (>6)
-            //  actually looks kinda cool when larger ships come in later...
+            //  begin warp - timing of rat fleet is ensured by destiny
             if (sClass <= Spawn::Class::Officer) {   // ratspawn will warp in, others will not.
                 // adjust warpIn point so show some variation instead of a straight line.
                 GPoint warpTo(warpToPoint);

--- a/src/eve-server/system/cosmicMgrs/SpawnMgr.cpp
+++ b/src/eve-server/system/cosmicMgrs/SpawnMgr.cpp
@@ -488,7 +488,13 @@ bool SpawnMgr::PrepSpawn(SystemBubble* pBubble, uint8 sClass/*Spawn::Class::None
 {
     if (pBubble == nullptr)
         return false;
+
+    // get security status value
     float secRating = m_system->GetSecValue();
+
+    // need to adjust value for -1.0/1.0 trusec system used below
+    secRating = 1.0f - secRating;
+
     bool anomaly = false;
     // get faction for this region
     uint32 factionID = factionRogueDrones;  // default to rogue drones.  this is my internal rogue drone factionID.


### PR DESCRIPTION
### Summary

Two issues were present that effectively prevented anything larger than an NPC cruiser from spawning in nullsec belts, which given the nature of nullsec was a suboptimal situation. Two issues were identified, affecting all security levels, and corrected:

1. **Incorrect security status used in class calculation** - The switches for determining spawn difficulty were written under the assumption sec status was between -1.0 and 1.0, however this was not the range being provided. This resulted in very easy spawn classes in most locations, and difficult ones in inappropriate ones.
2. **NPCs were being despawned before they could enter warp to the player's belt** - NPCs in the middle of nowhere with no nearby players, such as the random starting locations far away from any landmarks used by the rat spawner, are culled frequently. In the case of larger belt rats, like BC/BS types, they were nearly always culled before being able to enter warp.

Taken together, these issues effectively prevented the player from being able to fight anything larger than a cruiser in any belt, and usually only 1-3 frigates/destroyers even in nullsec.

### Before

<img width="1919" height="1015" alt="before" src="https://github.com/user-attachments/assets/b577c590-e35d-442f-8fc9-b6c2cc6efc06" />

This was fixed by adjusting the security status fetched by a fixed offset, and by allowing rats that are in bubbles with **no players** to immediately enter warp. The latter also solves the problem in the spawn manager comment regarding warp-in timing for larger spawns. Since it is virtually impossible for a player to see the rats getting into warp due to their randomly offset spawn bubble this fix has minimal question marks for immersion and safety.

### After

<img width="1919" height="1014" alt="after" src="https://github.com/user-attachments/assets/ae021f15-9328-45c0-a284-1a350ddc13e8" />

While spawns do still need some work regarding size, the classes are now correct and the warp-in effect works well!

### Testing
Testing of this change was done using a clean database, a phoenix for experiencing the spawns, and a merlin for verifying there were no side effects to players from the destiny change. Comparisons were done between staging and the PR branch - everything seems fine!

## Summary by Sourcery

Fix belt rat spawn behavior by correcting security status usage for spawn class selection and ensuring off-grid NPCs reliably warp into player belts.

Bug Fixes:
- Correct spawn class calculation by adjusting the security status value to match the expected -1.0 to 1.0 range.
- Prevent larger NPC belt spawns from being culled by allowing off-grid NPCs in empty bubbles to immediately enter warp instead of waiting for alignment timing.